### PR TITLE
perf: avoid cloning the entire source code on compiler errors

### DIFF
--- a/compiler/src/ast.rs
+++ b/compiler/src/ast.rs
@@ -439,10 +439,10 @@ pub enum Literal {
 impl Display for Literal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Literal::Void => write!(f, "void"),
-            Literal::Integer(n) => write!(f, "{n}"),
-            Literal::Float(n) => write!(f, "{n}"),
-            Literal::Boolean(b) => write!(f, "{b}"),
+            Self::Void => write!(f, "void"),
+            Self::Integer(n) => write!(f, "{n}"),
+            Self::Float(n) => write!(f, "{n}"),
+            Self::Boolean(b) => write!(f, "{b}"),
         }
     }
 }

--- a/compiler/src/ast.rs
+++ b/compiler/src/ast.rs
@@ -261,7 +261,7 @@ impl AstNode {
         }
     }
 
-    pub fn is_valid_assignment_lhs(&self) -> bool {
+    pub const fn is_valid_assignment_lhs(&self) -> bool {
         matches!(self, Self::Identifier { .. })
     }
 

--- a/compiler/src/ast.rs
+++ b/compiler/src/ast.rs
@@ -269,10 +269,7 @@ impl AstNode {
         if let AstNode::Identifier { name, span } = self {
             (name.clone(), span.clone())
         } else {
-            panic!(
-                "calling `unwrap_identifier` on non-identifier AstNode: {:?}",
-                self
-            )
+            panic!("calling `unwrap_identifier` on non-identifier AstNode: {self:?}")
         }
     }
 

--- a/compiler/src/compiler.rs
+++ b/compiler/src/compiler.rs
@@ -111,7 +111,7 @@ impl Display for SourceCodeError {
                 write!(f, "Kaba source code file must have '.kaba' extension")
             }
             Self::FileNotExist { path } => {
-                write!(f, "file '{}' is not exist", path.display())
+                write!(f, "file '{}' does not exist", path.display())
             }
         }
     }

--- a/compiler/src/compiler.rs
+++ b/compiler/src/compiler.rs
@@ -30,10 +30,9 @@ impl Compiler {
         let ext = path.extension().and_then(|e| e.to_str());
         if !matches!(ext, Some("kaba")) {
             return Err(Error {
-                path: Some(PathBuf::from(path)),
-                src: String::new(),
+                path: Some(path),
                 message: SourceCodeError::WrongExtension.to_string(),
-                span: None,
+                ..Error::default()
             });
         }
 
@@ -42,10 +41,9 @@ impl Compiler {
                 path: PathBuf::from(path),
             };
             return Err(Error {
-                path: Some(PathBuf::from(path)),
-                src: String::new(),
+                path: Some(path),
                 message: error.to_string(),
-                span: None,
+                ..Error::default()
             });
         }
 
@@ -58,14 +56,14 @@ impl Compiler {
     }
 
     /// Run the compilation process.
-    pub fn compile(mut self) -> Result<AstNode> {
+    pub fn compile(&mut self) -> Result<AstNode> {
         self.normalize_newlines();
 
         let tokens = lexer::lex(&self.src);
         if let Err(e) = &tokens {
             return Err(Error {
-                path: self.path,
-                src: String::from(&self.src),
+                path: self.path.as_deref(),
+                src: &self.src,
                 message: e.to_string(),
                 span: e.span(),
             });
@@ -74,8 +72,8 @@ impl Compiler {
         let ast = parser::parse(tokens.unwrap());
         if let Err(e) = &ast {
             return Err(Error {
-                path: self.path,
-                src: self.src,
+                path: self.path.as_deref(),
+                src: &self.src,
                 message: e.to_string(),
                 span: e.span(),
             });
@@ -83,8 +81,8 @@ impl Compiler {
 
         if let Err(e) = semantic::check(ast.as_ref().unwrap()) {
             return Err(Error {
-                path: self.path,
-                src: self.src,
+                path: self.path.as_deref(),
+                src: &self.src,
                 message: e.to_string(),
                 span: Some(e.span().clone()),
             });

--- a/compiler/src/error.rs
+++ b/compiler/src/error.rs
@@ -4,7 +4,7 @@
 use colored::Colorize;
 use indoc::writedoc;
 use logos::Span;
-use std::{fmt, path::PathBuf};
+use std::{fmt, path::Path};
 
 type Line = String;
 type Row = usize;
@@ -14,14 +14,14 @@ type Col = usize;
 /// process, alongside with the information of its source code
 /// file path and the source code itself.
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct Error {
-    pub path: Option<PathBuf>,
-    pub src: String,
+pub struct Error<'a> {
+    pub path: Option<&'a Path>,
+    pub src: &'a str,
     pub message: String,
     pub span: Option<Span>,
 }
 
-impl Error {
+impl Error<'_> {
     fn get_position(&self) -> Option<(Line, Row, Col)> {
         let span = self.span.as_ref().unwrap();
         let left_of_selected = &self.src[..span.start];
@@ -56,7 +56,7 @@ impl Error {
     }
 }
 
-impl fmt::Display for Error {
+impl fmt::Display for Error<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let label = "error:".bright_red().bold();
         let message = &self.message;
@@ -116,7 +116,7 @@ mod tests {
 
         for (span, expected_line, expected_row, expected_col) in cases {
             let error = Error {
-                src: String::from(input),
+                src: input,
                 span: Some(span),
                 ..Error::default()
             };

--- a/compiler/src/lexer.rs
+++ b/compiler/src/lexer.rs
@@ -137,7 +137,7 @@ pub enum TokenKind {
 }
 
 impl TokenKind {
-    fn is_comment(&self) -> bool {
+    const fn is_comment(&self) -> bool {
         matches!(self, Self::Comment(_))
     }
 }

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -1,9 +1,7 @@
 #![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
 
-use ast::AstNode;
 pub use compiler::Compiler;
 pub use error::Error;
-use std::path::Path;
 
 pub mod ast;
 mod compiler;
@@ -12,25 +10,4 @@ mod lexer;
 mod parser;
 mod semantic;
 
-type Result<T> = std::result::Result<T, Error>;
-
-/// Provide a quick way to compile a Kaba source code file, without the
-/// needs to manually lex the source code, parsing the tokens, etc.
-///
-/// # Examples
-///
-/// ```no_run
-/// use compiler as kabac;
-/// use std::path::PathBuf;
-///
-/// let source_code_file_path = PathBuf::from("my-program.kaba");
-///
-/// let result = kabac::compile(&source_code_file_path);
-///
-/// assert!(result.is_ok());
-/// ```
-///
-pub fn compile(path: &Path) -> Result<AstNode> {
-    let compiler = Compiler::from_file(path)?;
-    compiler.compile()
-}
+type Result<'a, T> = std::result::Result<T, Error<'a>>;

--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -32,10 +32,7 @@ impl Parser {
     fn parse(&mut self) -> Result<AstNode> {
         let mut body = vec![];
 
-        loop {
-            if self.current_token_is(&TokenKind::Eof) {
-                break;
-            }
+        while !self.current_token_is(&TokenKind::Eof) {
             let stmt = self.parse_statement()?;
             body.push(stmt)
         }

--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -25,7 +25,7 @@ struct Parser {
 }
 
 impl Parser {
-    fn new(tokens: Vec<Token>) -> Self {
+    const fn new(tokens: Vec<Token>) -> Self {
         Self { tokens, cursor: 0 }
     }
 

--- a/compiler/src/semantic/body.rs
+++ b/compiler/src/semantic/body.rs
@@ -11,7 +11,7 @@ pub struct BodyChecker<'a> {
 }
 
 impl<'a> BodyChecker<'a> {
-    pub fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
+    pub const fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
         Self { ss, node }
     }
 }

--- a/compiler/src/semantic/error.rs
+++ b/compiler/src/semantic/error.rs
@@ -173,8 +173,7 @@ impl Display for Error {
             Self::InvalidFunctionCallArgument { args, .. } => {
                 write!(
                     f,
-                    "unable to call function with argument(s) of type {:?}",
-                    args
+                    "unable to call function with argument(s) of type {args:?}"
                 )
             }
             Self::FunctionNotReturningValue { expect, .. } => {

--- a/compiler/src/semantic/expression.rs
+++ b/compiler/src/semantic/expression.rs
@@ -13,7 +13,7 @@ pub struct ExpressionChecker<'a> {
 }
 
 impl<'a> ExpressionChecker<'a> {
-    pub fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
+    pub const fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
         Self { ss, node }
     }
 }
@@ -125,7 +125,7 @@ struct FunctionCallChecker<'a> {
 }
 
 impl<'a> FunctionCallChecker<'a> {
-    fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
+    const fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
         Self { ss, node }
     }
 }

--- a/compiler/src/semantic/function.rs
+++ b/compiler/src/semantic/function.rs
@@ -18,7 +18,7 @@ pub struct FunctionDeclarationChecker<'a> {
 }
 
 impl<'a> FunctionDeclarationChecker<'a> {
-    pub fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
+    pub const fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
         Self { ss, node }
     }
 }
@@ -111,7 +111,7 @@ pub struct FunctionDefinitionChecker<'a> {
 }
 
 impl<'a> FunctionDefinitionChecker<'a> {
-    pub fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
+    pub const fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
         Self { ss, node }
     }
 }

--- a/compiler/src/semantic/statement.rs
+++ b/compiler/src/semantic/statement.rs
@@ -20,7 +20,7 @@ pub struct StatementChecker<'a> {
 }
 
 impl<'a> StatementChecker<'a> {
-    pub fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
+    pub const fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
         Self { ss, node }
     }
 }
@@ -133,7 +133,7 @@ struct VariableDeclarationChecker<'a> {
 }
 
 impl<'a> VariableDeclarationChecker<'a> {
-    fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
+    const fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
         Self { ss, node }
     }
 }
@@ -271,7 +271,7 @@ struct ConditionalBranchChecker<'a> {
 }
 
 impl<'a> ConditionalBranchChecker<'a> {
-    fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
+    const fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
         Self { ss, node }
     }
 }
@@ -380,7 +380,7 @@ struct WhileLoopChecker<'a> {
 }
 
 impl<'a> WhileLoopChecker<'a> {
-    fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
+    const fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
         Self { ss, node }
     }
 }
@@ -457,7 +457,7 @@ struct AssignmentChecker<'a> {
 }
 
 impl<'a> AssignmentChecker<'a> {
-    fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
+    const fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
         Self { ss, node }
     }
 }

--- a/compiler/src/semantic/tn.rs
+++ b/compiler/src/semantic/tn.rs
@@ -13,7 +13,7 @@ pub struct TypeNotationChecker<'a> {
 }
 
 impl<'a> TypeNotationChecker<'a> {
-    pub fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
+    pub const fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
         Self {
             ss,
             node,
@@ -21,7 +21,7 @@ impl<'a> TypeNotationChecker<'a> {
         }
     }
 
-    pub fn new_with_void_allowed(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
+    pub const fn new_with_void_allowed(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
         Self {
             ss,
             node,

--- a/compiler/src/semantic/types.rs
+++ b/compiler/src/semantic/types.rs
@@ -150,7 +150,7 @@ impl Display for Type {
                     .map(|t| t.to_string())
                     .collect::<Vec<_>>()
                     .join(",");
-                write!(f, "({}) -> {}", params_t, return_t)
+                write!(f, "({params_t}) -> {return_t}")
             }
         }
     }

--- a/compiler/src/semantic/types.rs
+++ b/compiler/src/semantic/types.rs
@@ -119,7 +119,7 @@ impl Type {
         matches!(self, Self::Identifier(id) if id == "Bool")
     }
 
-    fn is_callable(&self) -> bool {
+    const fn is_callable(&self) -> bool {
         matches!(self, Self::Callable { .. })
     }
 

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -1,14 +1,22 @@
+use compiler::Compiler;
 use kaba::runtime::{stream::RuntimeStream, Runtime};
 use std::{io, path::Path, process};
 
-pub fn handle(file_path: &Path) {
-    let res = compiler::compile(file_path);
-    if let Err(e) = res {
-        eprintln!("{e}");
-        process::exit(1);
-    }
+macro_rules! exit_on_error {
+    ($expression:expr) => {
+        match $expression {
+            Ok(value) => value,
+            Err(err) => {
+                eprintln!("{err}");
+                process::exit(1);
+            }
+        }
+    };
+}
 
-    let ast = res.unwrap();
+pub fn handle(file_path: &Path) {
+    let mut compiler = exit_on_error!(Compiler::from_file(file_path));
+    let ast = exit_on_error!(compiler.compile());
 
     let mut out_stream = io::stdout();
     let mut err_stream = io::stderr();

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -16,7 +16,7 @@ pub fn handle(file_path: &Path) {
 
     let res = Runtime::new(ast, streams).run();
     if let Err(e) = res {
-        eprintln!("{}", e);
+        eprintln!("{e}");
         process::exit(1);
     }
 }

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -22,9 +22,5 @@ pub fn handle(file_path: &Path) {
     let mut err_stream = io::stderr();
     let streams = RuntimeStream::new(&mut out_stream, &mut err_stream);
 
-    let res = Runtime::new(ast, streams).run();
-    if let Err(e) = res {
-        eprintln!("{e}");
-        process::exit(1);
-    }
+    exit_on_error!(Runtime::new(ast, streams).run());
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -268,7 +268,7 @@ impl<'a> Runtime<'a> {
 
     fn run_debug_statement(&self, expr: &AstNode) -> Result<()> {
         let val = self.run_expression(expr)?;
-        writeln!(self.streams.output(), "{}", val).unwrap();
+        writeln!(self.streams.output(), "{val}").unwrap();
         Ok(())
     }
 

--- a/src/runtime/value.rs
+++ b/src/runtime/value.rs
@@ -13,11 +13,11 @@ pub enum RuntimeValue {
 impl Display for RuntimeValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            RuntimeValue::Void => write!(f, "void"),
-            RuntimeValue::Integer(n) => write!(f, "{n}"),
-            RuntimeValue::Float(n) => write!(f, "{n}"),
-            RuntimeValue::Boolean(b) => write!(f, "{b}"),
-            RuntimeValue::Function(p) => write!(f, "<function #{p}>"),
+            Self::Void => write!(f, "void"),
+            Self::Integer(n) => write!(f, "{n}"),
+            Self::Float(n) => write!(f, "{n}"),
+            Self::Boolean(b) => write!(f, "{b}"),
+            Self::Function(p) => write!(f, "<function #{p}>"),
         }
     }
 }


### PR DESCRIPTION
Hai! Great project! Good job on it :)

This pull request primarily makes the compiler not clone the entire source code `String` and its `PathBuf` if it detects a compiler error, by simply borrowing them from the `Compiler` instance. (Note that because of this, the `compiler::compile()` utility function had to be removed, but it shouldn't be that bad!)

Other than that, i've also done other minor refactors as well, such as using macros, prioritizing using `Self` on `match self` statements, improving format specifiers, and marking several functions as `const` :)