### PR TITLE
Change `each` loop syntax

### DIFF
--- a/compiler/src/ast.rs
+++ b/compiler/src/ast.rs
@@ -40,8 +40,8 @@ pub enum AstNode {
     },
 
     Each {
-        iterable: Box<AstNode>,
         elem_id: Box<AstNode>,
+        iterable: Box<AstNode>,
         body: Vec<AstNode>,
         span: Span,
     },

--- a/compiler/src/lexer.rs
+++ b/compiler/src/lexer.rs
@@ -85,11 +85,12 @@ pub enum TokenKind {
     #[token("each")]     Each,
     #[token("break")]    Break,
     #[token("continue")] Continue,
-    #[token("as")]       As,
+    #[token("in")]       In,
     #[token("fn")]       Fn,
     #[token("return")]   Return,
     #[token("do")]       Do,
     #[token("end")]      End,
+    #[token("as")]       As,
     #[token("debug")]    Debug,
 
     //
@@ -162,11 +163,12 @@ impl Display for TokenKind {
             Self::Each => write!(f, "`each` keyword"),
             Self::Break => write!(f, "`break` keyword"),
             Self::Continue => write!(f, "`continue` keyword"),
-            Self::As => write!(f, "`as` keyword"),
+            Self::In => write!(f, "`in` keyword"),
             Self::Fn => write!(f, "`fn` keyword"),
             Self::Return => write!(f, "`return` keyword"),
             Self::Do => write!(f, "`do` keyword"),
             Self::End => write!(f, "`end` keyword"),
+            Self::As => write!(f, "`as` keyword"),
             Self::Debug => write!(f, "`debug` keyword"),
 
             Self::Add => write!(f, "addition operator (`+`)"),

--- a/compiler/src/parser/each_loop.rs
+++ b/compiler/src/parser/each_loop.rs
@@ -18,17 +18,17 @@ impl EachLoopParser<'_> {
     pub fn parse(&self) -> Result<AstNode> {
         let start = self.tokens.current().span.start;
 
-        // Expecting "while" keyword
+        // Expecting "each" keyword
         self.tokens.skip(&TokenKind::Each)?;
-
-        // Expecting expression
-        let arr = ExpressionParser::new(self.tokens).parse()?;
-
-        // Expecting "as" keyword
-        self.tokens.skip(&TokenKind::As)?;
 
         // Expecting element identifier
         let elem_id = self.parse_id()?;
+
+        // Expecting "in" keyword
+        self.tokens.skip(&TokenKind::In)?;
+
+        // Expecting expression
+        let arr = ExpressionParser::new(self.tokens).parse()?;
 
         // Expecting block
         let block = BlockParser::new(self.tokens).parse()?;
@@ -70,15 +70,15 @@ mod tests {
     #[test]
     fn each_statement() {
         parse_and_assert_result(
-            "each arr as elem do end",
+            "each elem in arr do end",
             AstNode::Each {
-                iterable: Box::new(AstNode::Identifier {
-                    name: String::from("arr"),
-                    span: 5..8,
-                }),
                 elem_id: Box::new(AstNode::Identifier {
                     name: String::from("elem"),
-                    span: 12..16,
+                    span: 5..9,
+                }),
+                iterable: Box::new(AstNode::Identifier {
+                    name: String::from("arr"),
+                    span: 13..16,
                 }),
                 body: vec![],
                 span: 0..23,

--- a/compiler/src/semantic/each_loop.rs
+++ b/compiler/src/semantic/each_loop.rs
@@ -104,12 +104,12 @@ mod tests {
     fn each_loop_statements() {
         assert_is_ok(indoc! {"
                 fn main() do
-                    each [1, 2, 3] as n do
+                    each n in [1, 2, 3] do
                         debug n;
                     end
 
                     var arr = [4, 5, 6];
-                    each arr as n do
+                    each n in arr do
                         debug n;
                     end
                 end
@@ -120,7 +120,7 @@ mod tests {
     fn each_loop_statement_with_non_array_expression() {
         assert_is_err(indoc! {"
                 fn main() do
-                    each true as n do
+                    each n in true do
                         debug n;
                     end
                 end
@@ -131,7 +131,7 @@ mod tests {
     fn accessing_elem_id_outside_scope() {
         assert_is_err(indoc! {"
                 fn main() do
-                    each [1, 2] as n do
+                    each n in [1, 2] do
                     end
 
                     debug n;
@@ -143,7 +143,7 @@ mod tests {
     fn iterating_over_an_empty_array_of_unknown_type() {
         assert_is_err(indoc! {"
                 fn main() do
-                    each [] as n do
+                    each n in [] do
                     end
                 end
             "});

--- a/docs/features.md
+++ b/docs/features.md
@@ -235,7 +235,7 @@ fn main() do
     var x = [];
 
     # And also not this...
-    each [] as i do
+    each i in [] do
     end
 end
 ```
@@ -356,7 +356,7 @@ To loop over each element of an iterable, use the `each` loop statement:
 
 ```text
 fn main() do
-    each [1, 2, 3, 4] as n do
+    each n in [1, 2, 3, 4] do
         debug n * 2;
     end
 end
@@ -366,7 +366,7 @@ It also supports `continue` and `break` statements:
 
 ```text
 fn main() do
-    each [1, 2, 3, 4, 5, 6] as i do
+    each i in [1, 2, 3, 4, 5, 6] do
         if i == 3 do
             continue;
         end

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -487,7 +487,7 @@ mod tests {
         assert_output_equal(
             indoc! {"
                 fn main() do
-                    each [1, 2, 3, 4, 5, 6] as n do
+                    each n in [1, 2, 3, 4, 5, 6] do
                         if n == 3 do
                             continue;
                         end


### PR DESCRIPTION
The syntax is changed from:

```
each [1, 2, 3] as n do
    # do something with `n`
end
```

To:

```
each n in [1, 2, 3] do
    # do something with `n`
end
```