### PR TITLE
rename built-in types and create symbol table

### DIFF
--- a/compiler/README.md
+++ b/compiler/README.md
@@ -54,7 +54,7 @@ Operator precedences will also be handled during this stage.
 
 The parser used by the compiler is implemented using a hand-written [recursive-descent parsing](https://en.wikipedia.org/wiki/Recursive_descent_parser) technique.
 
-### Semantic Checking
+### Semantic Analyzing
 
 This stage will catch all the semantic violation found in the AST.
 
@@ -64,7 +64,7 @@ For example, the following program:
 5 + false;
 ```
 
-... is valid according to the syntax of Kaba language, but it will be marked as invalid by the semantic checker as it does not make sense to add a number with a boolean (not in Kaba, at least😉).
+... is valid according to the syntax of Kaba language, but it will be marked as invalid by the semantic analyzer as it does not make sense to add a number with a boolean (not in Kaba, at least😉).
 
 This part is also implemented manually (hand-written).
 

--- a/compiler/src/ast.rs
+++ b/compiler/src/ast.rs
@@ -12,6 +12,7 @@ pub enum AstNode {
     // The root of all other AstNode variants
     Program {
         body: Vec<AstNode>,
+        span: Span,
     },
 
     VariableDeclaration {
@@ -234,9 +235,8 @@ pub enum AstNode {
 impl AstNode {
     pub fn span(&self) -> &Span {
         match self {
-            Self::Program { .. } => unreachable!(),
-
-            Self::VariableDeclaration { span, .. }
+            Self::Program { span, .. }
+            | Self::VariableDeclaration { span, .. }
             | Self::If { span, .. }
             | Self::Else { span, .. }
             | Self::While { span, .. }

--- a/compiler/src/ast.rs
+++ b/compiler/src/ast.rs
@@ -464,10 +464,10 @@ pub enum Literal {
     // A temporary value while the runtime is still using a tree-walk
     // interpreter mode
     Void,
+    Bool(bool),
 
-    Integer(u32),
+    Int(u32),
     Float(f64),
-    Boolean(bool),
 
     Array(Vec<AstNode>),
 }
@@ -476,9 +476,11 @@ impl Display for Literal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Void => write!(f, "void"),
-            Self::Integer(n) => write!(f, "{n}"),
+            Self::Bool(b) => write!(f, "{b}"),
+
+            Self::Int(n) => write!(f, "{n}"),
             Self::Float(n) => write!(f, "{n}"),
-            Self::Boolean(b) => write!(f, "{b}"),
+
             Self::Array(arr) => {
                 let joined = arr
                     .iter()

--- a/compiler/src/compiler.rs
+++ b/compiler/src/compiler.rs
@@ -20,36 +20,28 @@ impl Compiler {
     pub fn compile(&mut self) -> Result<AstNode> {
         self.normalize_newlines();
 
-        let tokens = lexer::lex(&self.src);
-        if let Err(e) = &tokens {
-            return Err(Error {
-                path: self.path.as_deref(),
-                src: &self.src,
-                message: e.to_string(),
-                span: e.span(),
-            });
-        }
+        let tokens = lexer::lex(&self.src).map_err(|e| Error {
+            path: self.path.as_deref(),
+            src: &self.src,
+            message: e.to_string(),
+            span: Some(e.span()),
+        })?;
 
-        let ast = parser::parse(tokens.unwrap());
-        if let Err(e) = &ast {
-            return Err(Error {
-                path: self.path.as_deref(),
-                src: &self.src,
-                message: e.to_string(),
-                span: e.span(),
-            });
-        }
+        let ast = parser::parse(tokens).map_err(|e| Error {
+            path: self.path.as_deref(),
+            src: &self.src,
+            message: e.to_string(),
+            span: Some(e.span()),
+        })?;
 
-        if let Err(e) = semantic::check(ast.as_ref().unwrap()) {
-            return Err(Error {
-                path: self.path.as_deref(),
-                src: &self.src,
-                message: e.to_string(),
-                span: Some(e.span().clone()),
-            });
-        }
+        let _sym_table = semantic::check(&ast).map_err(|e| Error {
+            path: self.path.as_deref(),
+            src: &self.src,
+            message: e.to_string(),
+            span: Some(e.span().clone()),
+        })?;
 
-        Ok(ast.unwrap())
+        Ok(ast)
     }
 
     // Normalize all newline characters to LF

--- a/compiler/src/compiler.rs
+++ b/compiler/src/compiler.rs
@@ -34,7 +34,7 @@ impl Compiler {
             span: Some(e.span()),
         })?;
 
-        let _sym_table = semantic::check(&ast).map_err(|e| Error {
+        let _sym_table = semantic::analyze(&ast).map_err(|e| Error {
             path: self.path.as_deref(),
             src: &self.src,
             message: e.to_string(),

--- a/compiler/src/lexer.rs
+++ b/compiler/src/lexer.rs
@@ -254,11 +254,13 @@ pub enum LexingError {
 }
 
 impl LexingError {
-    pub fn span(&self) -> Option<Span> {
+    pub fn span(&self) -> Span {
         match self {
-            Self::IdentifierStartsWithNumber { span, .. } => Some(span.clone()),
-            Self::UnknownToken { span, .. } => Some(span.clone()),
-            _ => None,
+            Self::IdentifierStartsWithNumber { span, .. } | Self::UnknownToken { span, .. } => {
+                span.clone()
+            }
+
+            _ => unreachable!(),
         }
     }
 }

--- a/compiler/src/lexer.rs
+++ b/compiler/src/lexer.rs
@@ -63,16 +63,16 @@ pub enum TokenKind {
     //
 
     #[regex("[0-9]+", priority = 2, callback = lex_integer)]
-    Integer(u32),
+    Int(u32),
 
     #[regex(r"[0-9]+\.[0-9]+", callback = lex_float)]
     Float(f64),
 
     #[token("true")]
-    BooleanTrue,
+    BoolTrue,
 
     #[token("false")]
-    BooleanFalse,
+    BoolFalse,
 
     //
     // Keywords
@@ -151,10 +151,10 @@ impl Display for TokenKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Identifier(_) => write!(f, "identifier"),
-            Self::Integer(_) => write!(f, "integer"),
+            Self::Int(_) => write!(f, "integer"),
             Self::Float(_) => write!(f, "float"),
-            Self::BooleanTrue => write!(f, "true"),
-            Self::BooleanFalse => write!(f, "false"),
+            Self::BoolTrue => write!(f, "true"),
+            Self::BoolFalse => write!(f, "false"),
 
             Self::Var => write!(f, "`var` keyword"),
             Self::If => write!(f, "`if` keyword"),
@@ -337,19 +337,19 @@ mod tests {
     #[test]
     fn test_lexing_an_integer_literal() {
         let input = "123";
-        lex_and_assert_result(input, TokenKind::Integer(input.parse().unwrap()));
+        lex_and_assert_result(input, TokenKind::Int(input.parse().unwrap()));
     }
 
     #[test]
     fn test_lexing_a_zero_literal() {
         let input = "0";
-        lex_and_assert_result(input, TokenKind::Integer(input.parse().unwrap()));
+        lex_and_assert_result(input, TokenKind::Int(input.parse().unwrap()));
     }
 
     #[test]
     fn test_lexing_a_big_integer_literal() {
         let input = "2147483647";
-        lex_and_assert_result(input, TokenKind::Integer(input.parse().unwrap()));
+        lex_and_assert_result(input, TokenKind::Int(input.parse().unwrap()));
     }
 
     //

--- a/compiler/src/parser.rs
+++ b/compiler/src/parser.rs
@@ -49,6 +49,9 @@ impl Parser {
             body.push(stmt)
         }
 
-        Ok(AstNode::Program { body })
+        Ok(AstNode::Program {
+            body,
+            span: 0..self.tokens.current().span.end,
+        })
     }
 }

--- a/compiler/src/parser/conditional.rs
+++ b/compiler/src/parser/conditional.rs
@@ -100,11 +100,11 @@ mod tests {
             AstNode::If {
                 cond: Box::new(AstNode::Gt {
                     lhs: Box::new(AstNode::Literal {
-                        lit: Literal::Integer(15),
+                        lit: Literal::Int(15),
                         span: 3..5,
                     }),
                     rhs: Box::new(AstNode::Literal {
-                        lit: Literal::Integer(10),
+                        lit: Literal::Int(10),
                         span: 8..10,
                     }),
                     span: 3..10,
@@ -115,7 +115,7 @@ mod tests {
                         span: 14..19,
                     }),
                     args: vec![AstNode::Literal {
-                        lit: Literal::Integer(1),
+                        lit: Literal::Int(1),
                         span: 20..21,
                     }],
                     span: 14..22,
@@ -132,13 +132,13 @@ mod tests {
             "if false do else if false do else do end",
             AstNode::If {
                 cond: Box::new(AstNode::Literal {
-                    lit: Literal::Boolean(false),
+                    lit: Literal::Bool(false),
                     span: 3..8,
                 }),
                 body: vec![],
                 or_else: Some(Box::new(AstNode::If {
                     cond: Box::new(AstNode::Literal {
-                        lit: Literal::Boolean(false),
+                        lit: Literal::Bool(false),
                         span: 20..25,
                     }),
                     body: vec![],

--- a/compiler/src/parser/error.rs
+++ b/compiler/src/parser/error.rs
@@ -14,9 +14,9 @@ pub enum ParsingError {
 }
 
 impl ParsingError {
-    pub fn span(&self) -> Option<Span> {
+    pub fn span(&self) -> Span {
         match self {
-            Self::UnexpectedToken { span, .. } => Some(span.clone()),
+            Self::UnexpectedToken { span, .. } => span.clone(),
         }
     }
 }

--- a/compiler/src/parser/expression.rs
+++ b/compiler/src/parser/expression.rs
@@ -429,10 +429,10 @@ impl ExpressionParser<'_> {
                     span: token.span,
                 })
             }
-            TokenKind::Integer(n) => {
+            TokenKind::Int(n) => {
                 self.tokens.advance();
                 Ok(AstNode::Literal {
-                    lit: Literal::Integer(n),
+                    lit: Literal::Int(n),
                     span: token.span,
                 })
             }
@@ -443,17 +443,17 @@ impl ExpressionParser<'_> {
                     span: token.span,
                 })
             }
-            TokenKind::BooleanTrue => {
+            TokenKind::BoolTrue => {
                 self.tokens.advance();
                 Ok(AstNode::Literal {
-                    lit: Literal::Boolean(true),
+                    lit: Literal::Bool(true),
                     span: token.span,
                 })
             }
-            TokenKind::BooleanFalse => {
+            TokenKind::BoolFalse => {
                 self.tokens.advance();
                 Ok(AstNode::Literal {
-                    lit: Literal::Boolean(false),
+                    lit: Literal::Bool(false),
                     span: token.span,
                 })
             }
@@ -571,11 +571,11 @@ mod tests {
                     }),
                     rhs: Box::new(AstNode::Mul {
                         lhs: Box::new(AstNode::Literal {
-                            lit: Literal::Integer(512),
+                            lit: Literal::Int(512),
                             span: 6..9,
                         }),
                         rhs: Box::new(AstNode::Literal {
-                            lit: Literal::Integer(200),
+                            lit: Literal::Int(200),
                             span: 12..15,
                         }),
                         span: 6..15,
@@ -588,7 +588,7 @@ mod tests {
                         span: 18..21,
                     }),
                     rhs: Box::new(AstNode::Literal {
-                        lit: Literal::Integer(3),
+                        lit: Literal::Int(3),
                         span: 24..25,
                     }),
                     span: 18..25,
@@ -609,7 +609,7 @@ mod tests {
                 }),
                 rhs: Box::new(AstNode::Mul {
                     lhs: Box::new(AstNode::Literal {
-                        lit: Literal::Integer(123),
+                        lit: Literal::Int(123),
                         span: 6..9,
                     }),
                     rhs: Box::new(AstNode::Identifier {
@@ -634,7 +634,7 @@ mod tests {
                 }),
                 rhs: Box::new(AstNode::Neg {
                     child: Box::new(AstNode::Literal {
-                        lit: Literal::Integer(5),
+                        lit: Literal::Int(5),
                         span: 6..7,
                     }),
                     span: 5..7,
@@ -655,7 +655,7 @@ mod tests {
                 }),
                 rhs: Box::new(AstNode::Neg {
                     child: Box::new(AstNode::Literal {
-                        lit: Literal::Integer(5),
+                        lit: Literal::Int(5),
                         span: 7..8,
                     }),
                     span: 6..8,
@@ -676,7 +676,7 @@ mod tests {
                 }),
                 rhs: Box::new(AstNode::Neg {
                     child: Box::new(AstNode::Literal {
-                        lit: Literal::Integer(5),
+                        lit: Literal::Int(5),
                         span: 7..8,
                     }),
                     span: 6..8,
@@ -697,7 +697,7 @@ mod tests {
                 }),
                 rhs: Box::new(AstNode::Neg {
                     child: Box::new(AstNode::Literal {
-                        lit: Literal::Integer(5),
+                        lit: Literal::Int(5),
                         span: 7..8,
                     }),
                     span: 6..8,
@@ -718,7 +718,7 @@ mod tests {
                 }),
                 rhs: Box::new(AstNode::Neg {
                     child: Box::new(AstNode::Literal {
-                        lit: Literal::Integer(5),
+                        lit: Literal::Int(5),
                         span: 7..8,
                     }),
                     span: 6..8,
@@ -739,7 +739,7 @@ mod tests {
                 }),
                 rhs: Box::new(AstNode::Neg {
                     child: Box::new(AstNode::Literal {
-                        lit: Literal::Integer(5),
+                        lit: Literal::Int(5),
                         span: 7..8,
                     }),
                     span: 6..8,
@@ -774,17 +774,17 @@ mod tests {
             AstNode::Mul {
                 lhs: Box::new(AstNode::Sub {
                     lhs: Box::new(AstNode::Literal {
-                        lit: Literal::Integer(123),
+                        lit: Literal::Int(123),
                         span: 1..4,
                     }),
                     rhs: Box::new(AstNode::Literal {
-                        lit: Literal::Integer(53),
+                        lit: Literal::Int(53),
                         span: 7..9,
                     }),
                     span: 1..9,
                 }),
                 rhs: Box::new(AstNode::Literal {
-                    lit: Literal::Integer(7),
+                    lit: Literal::Int(7),
                     span: 13..14,
                 }),
                 span: 0..14,
@@ -798,7 +798,7 @@ mod tests {
             "123 + (foo - 50);",
             AstNode::Add {
                 lhs: Box::new(AstNode::Literal {
-                    lit: Literal::Integer(123),
+                    lit: Literal::Int(123),
                     span: 0..3,
                 }),
                 rhs: Box::new(AstNode::Sub {
@@ -807,7 +807,7 @@ mod tests {
                         span: 7..10,
                     }),
                     rhs: Box::new(AstNode::Literal {
-                        lit: Literal::Integer(50),
+                        lit: Literal::Int(50),
                         span: 13..15,
                     }),
                     span: 7..15,
@@ -822,7 +822,7 @@ mod tests {
         parse_and_assert_result(
             "(((75)));",
             AstNode::Literal {
-                lit: Literal::Integer(75),
+                lit: Literal::Int(75),
                 span: 3..5,
             },
         );
@@ -840,16 +840,16 @@ mod tests {
                     }),
                     args: vec![
                         AstNode::Literal {
-                            lit: Literal::Integer(123),
+                            lit: Literal::Int(123),
                             span: 4..7,
                         },
                         AstNode::Add {
                             lhs: Box::new(AstNode::Literal {
-                                lit: Literal::Integer(50),
+                                lit: Literal::Int(50),
                                 span: 9..11,
                             }),
                             rhs: Box::new(AstNode::Literal {
-                                lit: Literal::Integer(2),
+                                lit: Literal::Int(2),
                                 span: 14..15,
                             }),
                             span: 9..15,
@@ -858,7 +858,7 @@ mod tests {
                     span: 0..16,
                 }),
                 rhs: Box::new(AstNode::Literal {
-                    lit: Literal::Integer(7),
+                    lit: Literal::Int(7),
                     span: 19..20,
                 }),
                 span: 0..20,
@@ -882,11 +882,11 @@ mod tests {
                     }),
                     args: vec![
                         AstNode::Literal {
-                            lit: Literal::Integer(123),
+                            lit: Literal::Int(123),
                             span: 8..11,
                         },
                         AstNode::Literal {
-                            lit: Literal::Integer(456),
+                            lit: Literal::Int(456),
                             span: 13..16,
                         },
                     ],
@@ -912,7 +912,7 @@ mod tests {
                 rhs: Box::new(AstNode::Mul {
                     lhs: Box::new(AstNode::Neg {
                         child: Box::new(AstNode::Literal {
-                            lit: Literal::Integer(5),
+                            lit: Literal::Int(5),
                             span: 10..11,
                         }),
                         span: 8..12,
@@ -920,7 +920,7 @@ mod tests {
                     rhs: Box::new(AstNode::Neg {
                         child: Box::new(AstNode::Neg {
                             child: Box::new(AstNode::Literal {
-                                lit: Literal::Integer(7),
+                                lit: Literal::Int(7),
                                 span: 19..20,
                             }),
                             span: 18..20,
@@ -971,7 +971,7 @@ mod tests {
                     span: 0..3,
                 }),
                 index: Box::new(AstNode::Literal {
-                    lit: Literal::Integer(3),
+                    lit: Literal::Int(3),
                     span: 4..5,
                 }),
                 span: 0..6,
@@ -990,13 +990,13 @@ mod tests {
                         span: 0..3,
                     }),
                     index: Box::new(AstNode::Literal {
-                        lit: Literal::Integer(3),
+                        lit: Literal::Int(3),
                         span: 4..5,
                     }),
                     span: 0..6,
                 }),
                 index: Box::new(AstNode::Literal {
-                    lit: Literal::Integer(10),
+                    lit: Literal::Int(10),
                     span: 7..9,
                 }),
                 span: 0..10,
@@ -1009,7 +1009,7 @@ mod tests {
         parse_and_assert_result(
             "true;",
             AstNode::Literal {
-                lit: Literal::Boolean(true),
+                lit: Literal::Bool(true),
                 span: 0..4,
             },
         );
@@ -1022,17 +1022,17 @@ mod tests {
             AstNode::Eq {
                 lhs: Box::new(AstNode::Gte {
                     lhs: Box::new(AstNode::Literal {
-                        lit: Literal::Integer(1),
+                        lit: Literal::Int(1),
                         span: 0..1,
                     }),
                     rhs: Box::new(AstNode::Literal {
-                        lit: Literal::Integer(5),
+                        lit: Literal::Int(5),
                         span: 5..6,
                     }),
                     span: 0..6,
                 }),
                 rhs: Box::new(AstNode::Literal {
-                    lit: Literal::Boolean(true),
+                    lit: Literal::Bool(true),
                     span: 10..14,
                 }),
                 span: 0..14,
@@ -1047,12 +1047,12 @@ mod tests {
             AstNode::And {
                 lhs: Box::new(AstNode::Or {
                     lhs: Box::new(AstNode::Literal {
-                        lit: Literal::Boolean(false),
+                        lit: Literal::Bool(false),
                         span: 0..5,
                     }),
                     rhs: Box::new(AstNode::Not {
                         child: Box::new(AstNode::Literal {
-                            lit: Literal::Boolean(false),
+                            lit: Literal::Bool(false),
                             span: 10..15,
                         }),
                         span: 9..15,
@@ -1060,7 +1060,7 @@ mod tests {
                     span: 0..15,
                 }),
                 rhs: Box::new(AstNode::Literal {
-                    lit: Literal::Boolean(true),
+                    lit: Literal::Bool(true),
                     span: 19..23,
                 }),
                 span: 0..23,
@@ -1085,7 +1085,7 @@ mod tests {
             "[5,];",
             AstNode::Literal {
                 lit: Literal::Array(vec![AstNode::Literal {
-                    lit: Literal::Integer(5),
+                    lit: Literal::Int(5),
                     span: 1..2,
                 }]),
                 span: 0..4,

--- a/compiler/src/parser/function.rs
+++ b/compiler/src/parser/function.rs
@@ -231,7 +231,7 @@ mod tests {
                 })),
                 body: vec![AstNode::Return {
                     expr: Some(Box::new(AstNode::Literal {
-                        lit: Literal::Integer(5),
+                        lit: Literal::Int(5),
                         span: 24..25,
                     })),
                     span: 17..25,

--- a/compiler/src/parser/function.rs
+++ b/compiler/src/parser/function.rs
@@ -144,7 +144,7 @@ mod tests {
     #[test]
     fn function_definition_with_parameters_and_trailing_comma() {
         parse_and_assert_result(
-            "fn foo(x: Int, y: Bool,) do end",
+            "fn foo(x: int, y: bool,) do end",
             AstNode::FunctionDefinition {
                 id: Box::new(AstNode::Identifier {
                     name: String::from("foo"),
@@ -157,7 +157,7 @@ mod tests {
                             span: 7..8,
                         },
                         tn: AstNode::TypeNotation {
-                            tn: TypeNotation::Identifier(String::from("Int")),
+                            tn: TypeNotation::Identifier(String::from("int")),
                             span: 10..13,
                         },
                     },
@@ -167,7 +167,7 @@ mod tests {
                             span: 15..16,
                         },
                         tn: AstNode::TypeNotation {
-                            tn: TypeNotation::Identifier(String::from("Bool")),
+                            tn: TypeNotation::Identifier(String::from("bool")),
                             span: 18..22,
                         },
                     },
@@ -182,7 +182,7 @@ mod tests {
     #[test]
     fn function_definition_with_parameter_and_body() {
         parse_and_assert_result(
-            "fn write(x: Int) do print(x); end",
+            "fn write(x: int) do print(x); end",
             AstNode::FunctionDefinition {
                 id: Box::new(AstNode::Identifier {
                     name: String::from("write"),
@@ -194,7 +194,7 @@ mod tests {
                         span: 9..10,
                     },
                     tn: AstNode::TypeNotation {
-                        tn: TypeNotation::Identifier(String::from("Int")),
+                        tn: TypeNotation::Identifier(String::from("int")),
                         span: 12..15,
                     },
                 }],
@@ -218,7 +218,7 @@ mod tests {
     #[test]
     fn function_definition_with_return_statement() {
         parse_and_assert_result(
-            "fn foo(): Int do return 5; end",
+            "fn foo(): int do return 5; end",
             AstNode::FunctionDefinition {
                 id: Box::new(AstNode::Identifier {
                     name: String::from("foo"),
@@ -226,7 +226,7 @@ mod tests {
                 }),
                 params: vec![],
                 return_tn: Some(Box::new(AstNode::TypeNotation {
-                    tn: TypeNotation::Identifier(String::from("Int")),
+                    tn: TypeNotation::Identifier(String::from("int")),
                     span: 10..13,
                 })),
                 body: vec![AstNode::Return {

--- a/compiler/src/parser/statement.rs
+++ b/compiler/src/parser/statement.rs
@@ -120,16 +120,16 @@ mod tests {
             AstNode::Debug {
                 expr: Box::new(AstNode::Add {
                     lhs: Box::new(AstNode::Literal {
-                        lit: Literal::Integer(5),
+                        lit: Literal::Int(5),
                         span: 6..7,
                     }),
                     rhs: Box::new(AstNode::Mul {
                         lhs: Box::new(AstNode::Literal {
-                            lit: Literal::Integer(5),
+                            lit: Literal::Int(5),
                             span: 10..11,
                         }),
                         rhs: Box::new(AstNode::Literal {
-                            lit: Literal::Integer(7),
+                            lit: Literal::Int(7),
                             span: 14..15,
                         }),
                         span: 10..15,

--- a/compiler/src/parser/test_util.rs
+++ b/compiler/src/parser/test_util.rs
@@ -5,7 +5,13 @@ pub fn parse_and_assert_result(input: &str, expect: AstNode) {
     let result = parse(tokens);
 
     assert!(result.is_ok());
-    assert_eq!(result.unwrap(), AstNode::Program { body: vec![expect] });
+    assert_eq!(
+        result.unwrap(),
+        AstNode::Program {
+            body: vec![expect],
+            span: 0..input.len(),
+        }
+    );
 }
 
 pub fn parse_and_assert_error(input: &str) {

--- a/compiler/src/parser/variable.rs
+++ b/compiler/src/parser/variable.rs
@@ -166,14 +166,14 @@ mod tests {
     #[test]
     fn variable_declaration_with_both_type_notation_and_initial_value() {
         parse_and_assert_result(
-            "var x: Int = 5;",
+            "var x: int = 5;",
             AstNode::VariableDeclaration {
                 id: Box::from(AstNode::Identifier {
                     name: String::from("x"),
                     span: 4..5,
                 }),
                 tn: Some(Box::from(AstNode::TypeNotation {
-                    tn: TypeNotation::Identifier(String::from("Int")),
+                    tn: TypeNotation::Identifier(String::from("int")),
                     span: 7..10,
                 })),
                 val: Box::new(AstNode::Literal {
@@ -188,7 +188,7 @@ mod tests {
     #[test]
     fn variable_declaration_with_function_type_notation() {
         parse_and_assert_result(
-            "var x: (Int) -> Void = foo;",
+            "var x: (int) -> void = foo;",
             AstNode::VariableDeclaration {
                 id: Box::from(AstNode::Identifier {
                     name: String::from("x"),
@@ -197,11 +197,11 @@ mod tests {
                 tn: Some(Box::from(AstNode::TypeNotation {
                     tn: TypeNotation::Callable {
                         params_tn: vec![AstNode::TypeNotation {
-                            tn: TypeNotation::Identifier(String::from("Int")),
+                            tn: TypeNotation::Identifier(String::from("int")),
                             span: 8..11,
                         }],
                         return_tn: Box::new(AstNode::TypeNotation {
-                            tn: TypeNotation::Identifier(String::from("Void")),
+                            tn: TypeNotation::Identifier(String::from("void")),
                             span: 16..20,
                         }),
                     },
@@ -219,7 +219,7 @@ mod tests {
     #[test]
     fn variable_declaration_with_nested_function_type_notation() {
         parse_and_assert_result(
-            "var x: (Int, Bool) -> (Int,) -> Void = foo;",
+            "var x: (int, bool) -> (int,) -> void = foo;",
             AstNode::VariableDeclaration {
                 id: Box::from(AstNode::Identifier {
                     name: String::from("x"),
@@ -229,22 +229,22 @@ mod tests {
                     tn: TypeNotation::Callable {
                         params_tn: vec![
                             AstNode::TypeNotation {
-                                tn: TypeNotation::Identifier(String::from("Int")),
+                                tn: TypeNotation::Identifier(String::from("int")),
                                 span: 8..11,
                             },
                             AstNode::TypeNotation {
-                                tn: TypeNotation::Identifier(String::from("Bool")),
+                                tn: TypeNotation::Identifier(String::from("bool")),
                                 span: 13..17,
                             },
                         ],
                         return_tn: Box::new(AstNode::TypeNotation {
                             tn: TypeNotation::Callable {
                                 params_tn: vec![AstNode::TypeNotation {
-                                    tn: TypeNotation::Identifier(String::from("Int")),
+                                    tn: TypeNotation::Identifier(String::from("int")),
                                     span: 23..26,
                                 }],
                                 return_tn: Box::new(AstNode::TypeNotation {
-                                    tn: TypeNotation::Identifier(String::from("Void")),
+                                    tn: TypeNotation::Identifier(String::from("void")),
                                     span: 32..36,
                                 }),
                             },
@@ -265,7 +265,7 @@ mod tests {
     #[test]
     fn variable_declaration_with_array_type() {
         parse_and_assert_result(
-            "var x: [][]Int = foo;",
+            "var x: [][]int = foo;",
             AstNode::VariableDeclaration {
                 id: Box::from(AstNode::Identifier {
                     name: String::from("x"),
@@ -276,7 +276,7 @@ mod tests {
                         elem_tn: Box::new(AstNode::TypeNotation {
                             tn: TypeNotation::Array {
                                 elem_tn: Box::new(AstNode::TypeNotation {
-                                    tn: TypeNotation::Identifier(String::from("Int")),
+                                    tn: TypeNotation::Identifier(String::from("int")),
                                     span: 11..14,
                                 }),
                             },

--- a/compiler/src/parser/variable.rs
+++ b/compiler/src/parser/variable.rs
@@ -99,7 +99,7 @@ mod tests {
                 tn: None,
                 val: Box::new(AstNode::Mul {
                     lhs: Box::new(AstNode::Literal {
-                        lit: Literal::Integer(123),
+                        lit: Literal::Int(123),
                         span: 10..13,
                     }),
                     rhs: Box::new(AstNode::Identifier {
@@ -125,11 +125,11 @@ mod tests {
                 tn: None,
                 val: Box::new(AstNode::Add {
                     lhs: Box::new(AstNode::Literal {
-                        lit: Literal::Integer(123),
+                        lit: Literal::Int(123),
                         span: 9..12,
                     }),
                     rhs: Box::new(AstNode::Literal {
-                        lit: Literal::Integer(50),
+                        lit: Literal::Int(50),
                         span: 15..17,
                     }),
                     span: 9..17,
@@ -177,7 +177,7 @@ mod tests {
                     span: 7..10,
                 })),
                 val: Box::new(AstNode::Literal {
-                    lit: Literal::Integer(5),
+                    lit: Literal::Int(5),
                     span: 13..14,
                 }),
                 span: 0..14,

--- a/compiler/src/parser/while_loop.rs
+++ b/compiler/src/parser/while_loop.rs
@@ -47,7 +47,7 @@ mod tests {
             "while true do end",
             AstNode::While {
                 cond: Box::new(AstNode::Literal {
-                    lit: Literal::Boolean(true),
+                    lit: Literal::Bool(true),
                     span: 6..10,
                 }),
                 body: vec![],
@@ -62,7 +62,7 @@ mod tests {
             "while true do continue; break; end",
             AstNode::While {
                 cond: Box::new(AstNode::Literal {
-                    lit: Literal::Boolean(true),
+                    lit: Literal::Bool(true),
                     span: 6..10,
                 }),
                 body: vec![

--- a/compiler/src/semantic.rs
+++ b/compiler/src/semantic.rs
@@ -1,13 +1,10 @@
 //! This module contains the implementation for type checking stage of the
 //! compiler.
 
-use self::{
-    error::{Error, Result},
-    types::Type,
-};
+use self::error::{Error, Result};
 use crate::ast::AstNode;
 use function::{FunctionDeclarationChecker, FunctionDefinitionChecker};
-use state::SharedState;
+use state::{symtable::SymTable, SharedState};
 
 mod assignment;
 mod body;
@@ -27,7 +24,7 @@ mod variable;
 mod while_loop;
 
 /// Provides a quick way to run semantic analysis on a Kaba AST.
-pub fn check(program: &AstNode) -> Result<Type> {
+pub fn check(program: &AstNode) -> Result<SymTable> {
     ProgramChecker::new(program).check()
 }
 
@@ -46,7 +43,7 @@ impl<'a> ProgramChecker<'a> {
 }
 
 impl ProgramChecker<'_> {
-    fn check(&self) -> Result<Type> {
+    fn check(self) -> Result<SymTable> {
         for stmt in self.body() {
             self.ensure_global_statement(stmt)?;
             FunctionDeclarationChecker::new(stmt, &self.state).check()?;
@@ -56,7 +53,7 @@ impl ProgramChecker<'_> {
             FunctionDefinitionChecker::new(stmt, &self.state).check()?;
         }
 
-        Ok(Type::Void)
+        Ok(self.state.take_st())
     }
 
     fn ensure_global_statement(&self, stmt: &AstNode) -> Result<()> {

--- a/compiler/src/semantic.rs
+++ b/compiler/src/semantic.rs
@@ -77,7 +77,7 @@ impl ProgramChecker<'_> {
     }
 
     fn body(&self) -> &[AstNode] {
-        if let AstNode::Program { body } = self.program {
+        if let AstNode::Program { body, .. } = self.program {
             body
         } else {
             unreachable!()

--- a/compiler/src/semantic.rs
+++ b/compiler/src/semantic.rs
@@ -56,7 +56,7 @@ impl ProgramChecker<'_> {
             FunctionDefinitionChecker::new(&self.ss, stmt).check()?;
         }
 
-        Ok(Type::new("Void"))
+        Ok(Type::Void)
     }
 
     fn ensure_global_statement(&self, stmt: &AstNode) -> Result<()> {

--- a/compiler/src/semantic.rs
+++ b/compiler/src/semantic.rs
@@ -40,7 +40,7 @@ impl<'a> ProgramChecker<'a> {
     fn new(program: &'a AstNode) -> Self {
         Self {
             program,
-            state: SharedState::default(),
+            state: SharedState::new(),
         }
     }
 }

--- a/compiler/src/semantic.rs
+++ b/compiler/src/semantic.rs
@@ -17,7 +17,6 @@ mod error;
 mod expression;
 mod function;
 mod literal;
-mod scope;
 mod state;
 mod statement;
 #[cfg(test)]

--- a/compiler/src/semantic.rs
+++ b/compiler/src/semantic.rs
@@ -1,9 +1,9 @@
-//! This module contains the implementation for type checking stage of the
+//! This module contains the implementation for semantic analyzing stage of the
 //! compiler.
 
 use self::error::{Error, Result};
 use crate::ast::AstNode;
-use function::{FunctionDeclarationChecker, FunctionDefinitionChecker};
+use function::{FunctionDeclarationAnalyzer, FunctionDefinitionAnalyzer};
 use state::{symtable::SymTable, SharedState};
 
 mod assignment;
@@ -24,16 +24,16 @@ mod variable;
 mod while_loop;
 
 /// Provides a quick way to run semantic analysis on a Kaba AST.
-pub fn check(program: &AstNode) -> Result<SymTable> {
-    ProgramChecker::new(program).check()
+pub fn analyze(program: &AstNode) -> Result<SymTable> {
+    ProgramAnalyzer::new(program).analyze()
 }
 
-struct ProgramChecker<'a> {
+struct ProgramAnalyzer<'a> {
     program: &'a AstNode,
     state: SharedState,
 }
 
-impl<'a> ProgramChecker<'a> {
+impl<'a> ProgramAnalyzer<'a> {
     fn new(program: &'a AstNode) -> Self {
         Self {
             program,
@@ -42,15 +42,15 @@ impl<'a> ProgramChecker<'a> {
     }
 }
 
-impl ProgramChecker<'_> {
-    fn check(self) -> Result<SymTable> {
+impl ProgramAnalyzer<'_> {
+    fn analyze(self) -> Result<SymTable> {
         for stmt in self.body() {
             self.ensure_global_statement(stmt)?;
-            FunctionDeclarationChecker::new(stmt, &self.state).check()?;
+            FunctionDeclarationAnalyzer::new(stmt, &self.state).analyze()?;
         }
 
         for stmt in self.body() {
-            FunctionDefinitionChecker::new(stmt, &self.state).check()?;
+            FunctionDefinitionAnalyzer::new(stmt, &self.state).analyze()?;
         }
 
         Ok(self.state.take_st())

--- a/compiler/src/semantic/assignment.rs
+++ b/compiler/src/semantic/assignment.rs
@@ -139,7 +139,7 @@ mod tests {
                     var x = 0;
                     x = 10;
 
-                    var y: Float = 0.0;
+                    var y: float = 0.0;
                     y = 5.0;
 
                     var z = false;
@@ -176,7 +176,7 @@ mod tests {
     fn assigning_value_with_non_existing_variable() {
         assert_is_err(indoc! {"
                 fn main() do
-                    var x: Float = 5.0;
+                    var x: float = 5.0;
                     x = y;
                 end
             "})

--- a/compiler/src/semantic/assignment.rs
+++ b/compiler/src/semantic/assignment.rs
@@ -1,7 +1,7 @@
 use super::{
     error::{Error, Result},
     expression::ExpressionChecker,
-    scope::ScopeStack,
+    state::SharedState,
     types::Type,
 };
 use crate::ast::AstNode;
@@ -49,13 +49,13 @@ use logos::Span;
 /// x += false;
 /// ```
 pub struct AssignmentChecker<'a> {
-    ss: &'a ScopeStack,
     node: &'a AstNode,
+    state: &'a SharedState,
 }
 
 impl<'a> AssignmentChecker<'a> {
-    pub const fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
-        Self { ss, node }
+    pub const fn new(node: &'a AstNode, state: &'a SharedState) -> Self {
+        Self { node, state }
     }
 }
 
@@ -90,8 +90,8 @@ impl AssignmentChecker<'_> {
     }
 
     fn check_assignment(&self, lhs: &AstNode, rhs: &AstNode, span: &Span) -> Result<Type> {
-        let lhs_t = ExpressionChecker::new(self.ss, lhs).check()?;
-        let rhs_t = ExpressionChecker::new(self.ss, rhs).check()?;
+        let lhs_t = ExpressionChecker::new(lhs, self.state).check()?;
+        let rhs_t = ExpressionChecker::new(rhs, self.state).check()?;
 
         Type::assert_assignable(&rhs_t, &lhs_t, || span.clone())?;
 
@@ -104,8 +104,8 @@ impl AssignmentChecker<'_> {
         rhs: &AstNode,
         span: &Span,
     ) -> Result<Type> {
-        let lhs_t = ExpressionChecker::new(self.ss, lhs).check()?;
-        let rhs_t = ExpressionChecker::new(self.ss, rhs).check()?;
+        let lhs_t = ExpressionChecker::new(lhs, self.state).check()?;
+        let rhs_t = ExpressionChecker::new(rhs, self.state).check()?;
 
         Type::assert_number(&lhs_t, || lhs.span().clone())?;
         Type::assert_number(&rhs_t, || rhs.span().clone())?;

--- a/compiler/src/semantic/assignment.rs
+++ b/compiler/src/semantic/assignment.rs
@@ -94,7 +94,7 @@ impl AssignmentAnalyzer<'_> {
 
         Type::assert_assignable(&rhs_t, &lhs_t, || span.clone())?;
 
-        Ok(Type::Void)
+        Ok(Type::void())
     }
 
     fn analyze_shorthand_assignment(
@@ -110,7 +110,7 @@ impl AssignmentAnalyzer<'_> {
         Type::assert_number(&rhs_t, || rhs.span().clone())?;
         Type::assert_assignable(&rhs_t, &lhs_t, || span.clone())?;
 
-        Ok(Type::Void)
+        Ok(Type::void())
     }
 
     fn lhs(&self) -> &AstNode {

--- a/compiler/src/semantic/assignment.rs
+++ b/compiler/src/semantic/assignment.rs
@@ -95,7 +95,7 @@ impl AssignmentChecker<'_> {
 
         Type::assert_assignable(&rhs_t, &lhs_t, || span.clone())?;
 
-        Ok(Type::new("Void"))
+        Ok(Type::Void)
     }
 
     fn check_shorthand_assignment(
@@ -111,7 +111,7 @@ impl AssignmentChecker<'_> {
         Type::assert_number(&rhs_t, || rhs.span().clone())?;
         Type::assert_assignable(&rhs_t, &lhs_t, || span.clone())?;
 
-        Ok(Type::new("Void"))
+        Ok(Type::Void)
     }
 
     fn lhs(&self) -> &AstNode {

--- a/compiler/src/semantic/body.rs
+++ b/compiler/src/semantic/body.rs
@@ -18,7 +18,7 @@ impl<'a> BodyAnalyzer<'a> {
 
 impl BodyAnalyzer<'_> {
     pub fn analyze(&self) -> Result<Type> {
-        let mut body_t = Type::Void;
+        let mut body_t = Type::void();
 
         for stmt in self.body() {
             let t = StatementAnalyzer::new(stmt, self.state).analyze()?;

--- a/compiler/src/semantic/body.rs
+++ b/compiler/src/semantic/body.rs
@@ -1,4 +1,4 @@
-use super::{error::Result, scope::ScopeStack, statement::StatementChecker, types::Type};
+use super::{error::Result, state::SharedState, statement::StatementChecker, types::Type};
 use crate::ast::AstNode;
 
 /// Checker for a statement body.
@@ -6,13 +6,13 @@ use crate::ast::AstNode;
 /// Statement bodies are consist of `>= 0` statements, so this checker will call
 /// the StatementChecker on each statement found in current body.
 pub struct BodyChecker<'a> {
-    ss: &'a ScopeStack,
     node: &'a AstNode,
+    state: &'a SharedState,
 }
 
 impl<'a> BodyChecker<'a> {
-    pub const fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
-        Self { ss, node }
+    pub const fn new(node: &'a AstNode, state: &'a SharedState) -> Self {
+        Self { node, state }
     }
 }
 
@@ -21,7 +21,7 @@ impl BodyChecker<'_> {
         let mut body_t = Type::Void;
 
         for stmt in self.body() {
-            let t = StatementChecker::new(self.ss, stmt).check()?;
+            let t = StatementChecker::new(stmt, self.state).check()?;
             if body_t.is_void() {
                 body_t = t;
             }

--- a/compiler/src/semantic/body.rs
+++ b/compiler/src/semantic/body.rs
@@ -1,27 +1,27 @@
-use super::{error::Result, state::SharedState, statement::StatementChecker, types::Type};
+use super::{error::Result, state::SharedState, statement::StatementAnalyzer, types::Type};
 use crate::ast::AstNode;
 
-/// Checker for a statement body.
+/// Analyzer for a statement body.
 ///
-/// Statement bodies are consist of `>= 0` statements, so this checker will call
-/// the StatementChecker on each statement found in current body.
-pub struct BodyChecker<'a> {
+/// Statement bodies are consist of `>= 0` statements, so this analyzer will
+/// call the [`StatementAnalyzer`] on each statement found in current body.
+pub struct BodyAnalyzer<'a> {
     node: &'a AstNode,
     state: &'a SharedState,
 }
 
-impl<'a> BodyChecker<'a> {
+impl<'a> BodyAnalyzer<'a> {
     pub const fn new(node: &'a AstNode, state: &'a SharedState) -> Self {
         Self { node, state }
     }
 }
 
-impl BodyChecker<'_> {
-    pub fn check(&self) -> Result<Type> {
+impl BodyAnalyzer<'_> {
+    pub fn analyze(&self) -> Result<Type> {
         let mut body_t = Type::Void;
 
         for stmt in self.body() {
-            let t = StatementChecker::new(stmt, self.state).check()?;
+            let t = StatementAnalyzer::new(stmt, self.state).analyze()?;
             if body_t.is_void() {
                 body_t = t;
             }

--- a/compiler/src/semantic/body.rs
+++ b/compiler/src/semantic/body.rs
@@ -18,7 +18,7 @@ impl<'a> BodyChecker<'a> {
 
 impl BodyChecker<'_> {
     pub fn check(&self) -> Result<Type> {
-        let mut body_t = Type::new("Void");
+        let mut body_t = Type::Void;
 
         for stmt in self.body() {
             let t = StatementChecker::new(self.ss, stmt).check()?;

--- a/compiler/src/semantic/conditional.rs
+++ b/compiler/src/semantic/conditional.rs
@@ -1,6 +1,9 @@
 use super::{
-    body::BodyChecker, error::Result, expression::ExpressionChecker, scope::Scope,
-    state::SharedState, types::Type,
+    body::BodyChecker,
+    error::Result,
+    expression::ExpressionChecker,
+    state::{scope::Scope, SharedState},
+    types::Type,
 };
 use crate::ast::AstNode;
 

--- a/compiler/src/semantic/conditional.rs
+++ b/compiler/src/semantic/conditional.rs
@@ -92,7 +92,7 @@ impl ConditionalBranchChecker<'_> {
 
         if self.or_else().is_none() {
             // Non-exhaustive branches, set to "Void"
-            return Ok(Type::new("Void"));
+            return Ok(Type::Void);
         }
 
         match self.or_else().unwrap() {
@@ -106,7 +106,7 @@ impl ConditionalBranchChecker<'_> {
                 if !return_t.is_void() && !branch_return_t.is_void() {
                     Ok(return_t)
                 } else {
-                    Ok(Type::new("Void"))
+                    Ok(Type::Void)
                 }
             }
 
@@ -120,7 +120,7 @@ impl ConditionalBranchChecker<'_> {
                 if !return_t.is_void() && !branch_return_t.is_void() {
                     Ok(return_t)
                 } else {
-                    Ok(Type::new("Void"))
+                    Ok(Type::Void)
                 }
             }
 

--- a/compiler/src/semantic/conditional.rs
+++ b/compiler/src/semantic/conditional.rs
@@ -2,7 +2,7 @@ use super::{
     body::BodyChecker,
     error::Result,
     expression::ExpressionChecker,
-    state::{scope::Scope, SharedState},
+    state::{scope::ScopeVariant, SharedState},
     types::Type,
 };
 use crate::ast::AstNode;
@@ -86,12 +86,9 @@ impl ConditionalBranchChecker<'_> {
 
         // Check all statements inside the body with a new scope
 
-        let return_t = self
-            .state
-            .ss
-            .with_scope(Scope::new_conditional_scope(), || {
-                BodyChecker::new(self.node, self.state).check()
-            })?;
+        let return_t = self.state.with_scope(ScopeVariant::Conditional, || {
+            BodyChecker::new(self.node, self.state).check()
+        })?;
 
         if self.or_else().is_none() {
             // Non-exhaustive branches, set to "Void"
@@ -116,12 +113,9 @@ impl ConditionalBranchChecker<'_> {
             AstNode::Else { .. } => {
                 // Check all statements inside the body with a new scope
 
-                let branch_return_t = self
-                    .state
-                    .ss
-                    .with_scope(Scope::new_conditional_scope(), || {
-                        BodyChecker::new(self.or_else().unwrap(), self.state).check()
-                    })?;
+                let branch_return_t = self.state.with_scope(ScopeVariant::Conditional, || {
+                    BodyChecker::new(self.or_else().unwrap(), self.state).check()
+                })?;
 
                 if !return_t.is_void() && !branch_return_t.is_void() {
                     Ok(return_t)

--- a/compiler/src/semantic/conditional.rs
+++ b/compiler/src/semantic/conditional.rs
@@ -34,7 +34,7 @@ use crate::ast::AstNode;
 /// * It can be the last statement of a function:
 ///
 /// ```text
-/// fn foo(): Int do
+/// fn foo(): int do
 ///     if false do
 ///         return 5;
 ///     else do
@@ -60,7 +60,7 @@ use crate::ast::AstNode;
 ///   the function:
 ///
 /// ```text
-/// fn foo(): Int do
+/// fn foo(): int do
 ///     if !true do
 ///         return 1;
 ///     else do

--- a/compiler/src/semantic/conditional.rs
+++ b/compiler/src/semantic/conditional.rs
@@ -92,7 +92,7 @@ impl ConditionalBranchAnalyzer<'_> {
 
         if self.or_else().is_none() {
             // Non-exhaustive branches, set to "Void"
-            return Ok(Type::Void);
+            return Ok(Type::void());
         }
 
         match self.or_else().unwrap() {
@@ -107,7 +107,7 @@ impl ConditionalBranchAnalyzer<'_> {
                 if !return_t.is_void() && !branch_return_t.is_void() {
                     Ok(return_t)
                 } else {
-                    Ok(Type::Void)
+                    Ok(Type::void())
                 }
             }
 
@@ -121,7 +121,7 @@ impl ConditionalBranchAnalyzer<'_> {
                 if !return_t.is_void() && !branch_return_t.is_void() {
                     Ok(return_t)
                 } else {
-                    Ok(Type::Void)
+                    Ok(Type::void())
                 }
             }
 

--- a/compiler/src/semantic/each_loop.rs
+++ b/compiler/src/semantic/each_loop.rs
@@ -2,8 +2,7 @@ use super::{
     body::BodyChecker,
     error::{Error, Result},
     expression::ExpressionChecker,
-    scope::Scope,
-    state::SharedState,
+    state::{scope::Scope, SharedState},
     types::Type,
 };
 use crate::ast::AstNode;

--- a/compiler/src/semantic/each_loop.rs
+++ b/compiler/src/semantic/each_loop.rs
@@ -75,7 +75,7 @@ impl EachLoopChecker<'_> {
             BodyChecker::new(self.ss, self.node).check()
         })?;
 
-        Ok(Type::new("Void"))
+        Ok(Type::Void)
     }
 
     fn iterable(&self) -> &AstNode {

--- a/compiler/src/semantic/each_loop.rs
+++ b/compiler/src/semantic/each_loop.rs
@@ -75,7 +75,7 @@ impl EachLoopAnalyzer<'_> {
             BodyAnalyzer::new(self.node, self.state).analyze()
         })?;
 
-        Ok(Type::Void)
+        Ok(Type::void())
     }
 
     fn iterable(&self) -> &AstNode {

--- a/compiler/src/semantic/each_loop.rs
+++ b/compiler/src/semantic/each_loop.rs
@@ -2,7 +2,7 @@ use super::{
     body::BodyChecker,
     error::{Error, Result},
     expression::ExpressionChecker,
-    state::{scope::Scope, SharedState},
+    state::{scope::ScopeVariant, SharedState},
     types::Type,
 };
 use crate::ast::AstNode;
@@ -67,10 +67,9 @@ impl EachLoopChecker<'_> {
 
         // Check all statements inside the body with a new scope
 
-        self.state.ss.with_scope(Scope::new_loop_scope(), || {
+        self.state.with_scope(ScopeVariant::Loop, || {
             self.state
-                .ss
-                .save_symbol_or_else(&elem_id, elem_t.clone(), || unreachable!())
+                .save_sym_or_else(&elem_id, elem_t.clone(), || unreachable!())
                 .unwrap();
 
             BodyChecker::new(self.node, self.state).check()

--- a/compiler/src/semantic/each_loop.rs
+++ b/compiler/src/semantic/each_loop.rs
@@ -1,13 +1,13 @@
 use super::{
-    body::BodyChecker,
+    body::BodyAnalyzer,
     error::{Error, Result},
-    expression::ExpressionChecker,
+    expression::ExpressionAnalyzer,
     state::{scope::ScopeVariant, SharedState},
     types::Type,
 };
 use crate::ast::AstNode;
 
-/// Checker for `each` loop statement.
+/// Analyzer for `each` loop statement.
 ///
 /// ### ✅ Valid Examples
 ///
@@ -38,20 +38,20 @@ use crate::ast::AstNode;
 ///     # Invalid
 /// end
 /// ```
-pub struct EachLoopChecker<'a> {
+pub struct EachLoopAnalyzer<'a> {
     node: &'a AstNode,
     state: &'a SharedState,
 }
 
-impl<'a> EachLoopChecker<'a> {
+impl<'a> EachLoopAnalyzer<'a> {
     pub const fn new(node: &'a AstNode, state: &'a SharedState) -> Self {
         Self { node, state }
     }
 }
 
-impl EachLoopChecker<'_> {
-    pub fn check(&self) -> Result<Type> {
-        let expr_t = ExpressionChecker::new(self.iterable(), self.state).check()?;
+impl EachLoopAnalyzer<'_> {
+    pub fn analyze(&self) -> Result<Type> {
+        let expr_t = ExpressionAnalyzer::new(self.iterable(), self.state).analyze()?;
 
         Type::assert_iterable(&expr_t, || self.iterable().span().clone())?;
 
@@ -72,7 +72,7 @@ impl EachLoopChecker<'_> {
                 .save_sym_or_else(&elem_id, elem_t.clone(), || unreachable!())
                 .unwrap();
 
-            BodyChecker::new(self.node, self.state).check()
+            BodyAnalyzer::new(self.node, self.state).analyze()
         })?;
 
         Ok(Type::Void)

--- a/compiler/src/semantic/error.rs
+++ b/compiler/src/semantic/error.rs
@@ -50,6 +50,11 @@ pub enum Error {
         span: Span,
     },
 
+    NonSignableNumberType {
+        t: Type,
+        span: Span,
+    },
+
     NonBooleanType {
         span: Span,
     },
@@ -95,6 +100,7 @@ impl Error {
             | Self::SymbolAlreadyExist { span, .. }
             | Self::SymbolDoesNotExist { span, .. }
             | Self::NonNumberType { span, .. }
+            | Self::NonSignableNumberType { span, .. }
             | Self::NonBooleanType { span, .. }
             | Self::UnexpectedStatement { span, .. }
             | Self::InvalidFunctionCallArgument { span, .. }
@@ -134,6 +140,9 @@ impl Display for Error {
             }
             Self::NonNumberType { .. } => {
                 write!(f, "not a number")
+            }
+            Self::NonSignableNumberType { t, .. } => {
+                write!(f, "not a signable number: `{t}`")
             }
             Self::NonBooleanType { .. } => {
                 write!(f, "not a boolean")

--- a/compiler/src/semantic/expression.rs
+++ b/compiler/src/semantic/expression.rs
@@ -58,8 +58,7 @@ impl ExpressionChecker<'_> {
 
             AstNode::Identifier { name, span } => {
                 self.state
-                    .ss
-                    .get_symbol_t(name)
+                    .get_sym_t(name)
                     .ok_or_else(|| Error::SymbolDoesNotExist {
                         id: String::from(name),
                         span: span.clone(),

--- a/compiler/src/semantic/expression.rs
+++ b/compiler/src/semantic/expression.rs
@@ -3,7 +3,7 @@ use super::{
     error::{Error, Result},
     literal::LiteralAnalyzer,
     state::SharedState,
-    types::Type,
+    types::{LiteralType, Type},
 };
 use crate::ast::AstNode;
 use function_call::FunctionCallAnalyzer;
@@ -116,8 +116,10 @@ impl ExpressionAnalyzer<'_> {
         Type::assert_number(&rhs_t, || rhs.span().clone())?;
         Type::assert_same(&lhs_t, &rhs_t, || lhs.span().start..rhs.span().end)?;
 
-        if lhs_t == Type::UIntLiteral && rhs_t == Type::UIntLiteral {
-            return Ok(Type::UIntLiteral);
+        if lhs_t == Type::Literal(LiteralType::UnsignedInt)
+            && rhs_t == Type::Literal(LiteralType::UnsignedInt)
+        {
+            return Ok(Type::Literal(LiteralType::UnsignedInt));
         }
 
         Ok(lhs_t)
@@ -138,7 +140,7 @@ impl ExpressionAnalyzer<'_> {
 
         if child_t.is_number_literal() {
             // Must change into signed integer
-            Ok(Type::IntLiteral)
+            Ok(Type::Literal(LiteralType::Int))
         } else {
             Ok(child_t)
         }
@@ -149,12 +151,12 @@ impl ExpressionAnalyzer<'_> {
 mod tests {
     use crate::semantic::{
         test_util::{assert_expression_is_err, assert_expression_type},
-        types::Type,
+        types::{LiteralType, Type},
     };
 
     #[test]
     fn math_expression_returning_int_type() {
-        assert_expression_type("-5 + 50 * 200 / 7 - 999;", Type::IntLiteral);
+        assert_expression_type("-5 + 50 * 200 / 7 - 999;", Type::Literal(LiteralType::Int));
     }
 
     #[test]

--- a/compiler/src/semantic/expression.rs
+++ b/compiler/src/semantic/expression.rs
@@ -81,7 +81,7 @@ impl ExpressionChecker<'_> {
         Type::assert_boolean(&lhs_t, || lhs.span().clone())?;
         Type::assert_boolean(&rhs_t, || rhs.span().clone())?;
 
-        Ok(Type::new("Bool"))
+        Ok(Type::Bool)
     }
 
     fn check_equality_operation(&self, lhs: &AstNode, rhs: &AstNode) -> Result<Type> {
@@ -90,7 +90,7 @@ impl ExpressionChecker<'_> {
 
         Type::assert_same(&lhs_t, &rhs_t, || lhs.span().start..rhs.span().end)?;
 
-        Ok(Type::new("Bool"))
+        Ok(Type::Bool)
     }
 
     fn check_comparison_operation(&self, lhs: &AstNode, rhs: &AstNode) -> Result<Type> {
@@ -101,7 +101,7 @@ impl ExpressionChecker<'_> {
         Type::assert_number(&rhs_t, || rhs.span().clone())?;
         Type::assert_same(&lhs_t, &rhs_t, || lhs.span().start..rhs.span().end)?;
 
-        Ok(Type::new("Bool"))
+        Ok(Type::Bool)
     }
 
     fn check_math_binary_operation(&self, lhs: &AstNode, rhs: &AstNode) -> Result<Type> {
@@ -124,7 +124,7 @@ impl ExpressionChecker<'_> {
 
         Type::assert_boolean(&child_t, || child.span().clone())?;
 
-        Ok(Type::new("Bool"))
+        Ok(Type::Bool)
     }
 
     fn check_neg_operation(&self, child: &AstNode) -> Result<Type> {
@@ -155,17 +155,17 @@ mod tests {
 
     #[test]
     fn float_modulo_operation() {
-        assert_expression_type("99.9 % 0.1;", Type::new("Float"));
+        assert_expression_type("99.9 % 0.1;", Type::Float);
     }
 
     #[test]
     fn comparison_and_equality_operations() {
-        assert_expression_type("767 >= 900 == (45 < 67);", Type::new("Bool"));
+        assert_expression_type("767 >= 900 == (45 < 67);", Type::Bool);
     }
 
     #[test]
     fn logical_or_and_and_operations() {
-        assert_expression_type("false || !false && 50 > 0;", Type::new("Bool"));
+        assert_expression_type("false || !false && 50 > 0;", Type::Bool);
     }
 
     #[test]

--- a/compiler/src/semantic/expression.rs
+++ b/compiler/src/semantic/expression.rs
@@ -85,7 +85,7 @@ impl ExpressionAnalyzer<'_> {
         Type::assert_boolean(&lhs_t, || lhs.span().clone())?;
         Type::assert_boolean(&rhs_t, || rhs.span().clone())?;
 
-        Ok(Type::Bool)
+        Ok(Type::bool())
     }
 
     fn analyze_equality_operation(&self, lhs: &AstNode, rhs: &AstNode) -> Result<Type> {
@@ -94,7 +94,7 @@ impl ExpressionAnalyzer<'_> {
 
         Type::assert_same(&lhs_t, &rhs_t, || lhs.span().start..rhs.span().end)?;
 
-        Ok(Type::Bool)
+        Ok(Type::bool())
     }
 
     fn analyze_comparison_operation(&self, lhs: &AstNode, rhs: &AstNode) -> Result<Type> {
@@ -105,7 +105,7 @@ impl ExpressionAnalyzer<'_> {
         Type::assert_number(&rhs_t, || rhs.span().clone())?;
         Type::assert_same(&lhs_t, &rhs_t, || lhs.span().start..rhs.span().end)?;
 
-        Ok(Type::Bool)
+        Ok(Type::bool())
     }
 
     fn analyze_math_binary_operation(&self, lhs: &AstNode, rhs: &AstNode) -> Result<Type> {
@@ -130,7 +130,7 @@ impl ExpressionAnalyzer<'_> {
 
         Type::assert_boolean(&child_t, || child.span().clone())?;
 
-        Ok(Type::Bool)
+        Ok(Type::bool())
     }
 
     fn analyze_neg_operation(&self, child: &AstNode) -> Result<Type> {
@@ -161,17 +161,17 @@ mod tests {
 
     #[test]
     fn float_modulo_operation() {
-        assert_expression_type("99.9 % 0.1;", Type::Float);
+        assert_expression_type("99.9 % 0.1;", Type::float());
     }
 
     #[test]
     fn comparison_and_equality_operations() {
-        assert_expression_type("767 >= 900 == (45 < 67);", Type::Bool);
+        assert_expression_type("767 >= 900 == (45 < 67);", Type::bool());
     }
 
     #[test]
     fn logical_or_and_and_operations() {
-        assert_expression_type("false || !false && 50 > 0;", Type::Bool);
+        assert_expression_type("false || !false && 50 > 0;", Type::bool());
     }
 
     #[test]

--- a/compiler/src/semantic/expression/function_call.rs
+++ b/compiler/src/semantic/expression/function_call.rs
@@ -1,4 +1,4 @@
-use super::ExpressionChecker;
+use super::ExpressionAnalyzer;
 use crate::{
     ast::AstNode,
     semantic::{
@@ -9,21 +9,21 @@ use crate::{
 };
 use logos::Span;
 
-/// Checker for function call expression rule.
-pub struct FunctionCallChecker<'a> {
+/// Analyzer for function call expression rule.
+pub struct FunctionCallAnalyzer<'a> {
     node: &'a AstNode,
     state: &'a SharedState,
 }
 
-impl<'a> FunctionCallChecker<'a> {
+impl<'a> FunctionCallAnalyzer<'a> {
     pub const fn new(node: &'a AstNode, state: &'a SharedState) -> Self {
         Self { node, state }
     }
 }
 
-impl FunctionCallChecker<'_> {
-    pub fn check(&self) -> Result<Type> {
-        let fn_t = ExpressionChecker::new(self.callee(), self.state).check()?;
+impl FunctionCallAnalyzer<'_> {
+    pub fn analyze(&self) -> Result<Type> {
+        let fn_t = ExpressionAnalyzer::new(self.callee(), self.state).analyze()?;
         Type::assert_callable(&fn_t, || self.callee().span().clone())?;
 
         let args_t = self.args_t()?;
@@ -45,7 +45,7 @@ impl FunctionCallChecker<'_> {
     fn args_t(&self) -> Result<Vec<Type>> {
         let mut args_t = vec![];
         for arg in self.args() {
-            let t = ExpressionChecker::new(arg, self.state).check()?;
+            let t = ExpressionAnalyzer::new(arg, self.state).analyze()?;
             args_t.push(t);
         }
 

--- a/compiler/src/semantic/expression/index_access.rs
+++ b/compiler/src/semantic/expression/index_access.rs
@@ -1,27 +1,27 @@
-use super::ExpressionChecker;
+use super::ExpressionAnalyzer;
 use crate::{
     ast::AstNode,
     semantic::{error::Result, state::SharedState, types::Type},
 };
 
-/// Checker for index access expression rule.
-pub struct IndexAccessChecker<'a> {
+/// Analyzer for index access expression rule.
+pub struct IndexAccessAnalyzer<'a> {
     node: &'a AstNode,
     state: &'a SharedState,
 }
 
-impl<'a> IndexAccessChecker<'a> {
+impl<'a> IndexAccessAnalyzer<'a> {
     pub const fn new(node: &'a AstNode, state: &'a SharedState) -> Self {
         Self { node, state }
     }
 }
 
-impl IndexAccessChecker<'_> {
-    pub fn check(&self) -> Result<Type> {
-        let obj_t = ExpressionChecker::new(self.obj(), self.state).check()?;
+impl IndexAccessAnalyzer<'_> {
+    pub fn analyze(&self) -> Result<Type> {
+        let obj_t = ExpressionAnalyzer::new(self.obj(), self.state).analyze()?;
         Type::assert_indexable(&obj_t, || self.obj().span().clone())?;
 
-        let index_t = ExpressionChecker::new(self.index(), self.state).check()?;
+        let index_t = ExpressionAnalyzer::new(self.index(), self.state).analyze()?;
         Type::assert_number(&index_t, || self.index().span().clone())?;
 
         match obj_t {

--- a/compiler/src/semantic/expression/index_access.rs
+++ b/compiler/src/semantic/expression/index_access.rs
@@ -1,27 +1,27 @@
 use super::ExpressionChecker;
 use crate::{
     ast::AstNode,
-    semantic::{error::Result, scope::ScopeStack, types::Type},
+    semantic::{error::Result, state::SharedState, types::Type},
 };
 
 /// Checker for index access expression rule.
 pub struct IndexAccessChecker<'a> {
-    ss: &'a ScopeStack,
     node: &'a AstNode,
+    state: &'a SharedState,
 }
 
 impl<'a> IndexAccessChecker<'a> {
-    pub const fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
-        Self { ss, node }
+    pub const fn new(node: &'a AstNode, state: &'a SharedState) -> Self {
+        Self { node, state }
     }
 }
 
 impl IndexAccessChecker<'_> {
     pub fn check(&self) -> Result<Type> {
-        let obj_t = ExpressionChecker::new(self.ss, self.obj()).check()?;
+        let obj_t = ExpressionChecker::new(self.obj(), self.state).check()?;
         Type::assert_indexable(&obj_t, || self.obj().span().clone())?;
 
-        let index_t = ExpressionChecker::new(self.ss, self.index()).check()?;
+        let index_t = ExpressionChecker::new(self.index(), self.state).check()?;
         Type::assert_number(&index_t, || self.index().span().clone())?;
 
         match obj_t {

--- a/compiler/src/semantic/expression/index_access.rs
+++ b/compiler/src/semantic/expression/index_access.rs
@@ -51,14 +51,14 @@ impl IndexAccessAnalyzer<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::semantic::test_util::assert_expression_type;
+    use crate::semantic::{test_util::assert_expression_type, types::LiteralType};
 
     #[test]
     fn index_accessing() {
         assert_expression_type(
             "[[1, 2]][0];",
             Type::Array {
-                elem_t: Some(Box::new(Type::UIntLiteral)),
+                elem_t: Some(Box::new(Type::Literal(LiteralType::UnsignedInt))),
             },
         );
     }

--- a/compiler/src/semantic/expression/index_access.rs
+++ b/compiler/src/semantic/expression/index_access.rs
@@ -58,7 +58,7 @@ mod tests {
         assert_expression_type(
             "[[1, 2]][0];",
             Type::Array {
-                elem_t: Some(Box::new(Type::new("Int"))),
+                elem_t: Some(Box::new(Type::UIntLiteral)),
             },
         );
     }

--- a/compiler/src/semantic/function.rs
+++ b/compiler/src/semantic/function.rs
@@ -65,7 +65,7 @@ impl FunctionDeclarationAnalyzer<'_> {
     }
 
     fn return_t(&self) -> Type {
-        self.return_tn().map_or(Type::Void, Type::from)
+        self.return_tn().map_or(Type::void(), Type::from)
     }
 
     // Save function information to the ScopeStack.
@@ -138,7 +138,7 @@ impl FunctionDefinitionAnalyzer<'_> {
                 if !return_t.is_void() && body_t.is_void() {
                     return Err(Error::ReturnTypeMismatch {
                         expected: return_t,
-                        get: Type::Void,
+                        get: Type::void(),
                         span: self.id().span().clone(),
                     });
                 }
@@ -147,7 +147,7 @@ impl FunctionDefinitionAnalyzer<'_> {
             },
         )?;
 
-        Ok(Type::Void)
+        Ok(Type::void())
     }
 
     fn save_params_to_stack(&self, params: &[((String, Span), Type)]) -> Result<()> {

--- a/compiler/src/semantic/function.rs
+++ b/compiler/src/semantic/function.rs
@@ -1,8 +1,7 @@
 use super::{
     body::BodyChecker,
     error::{Error, Result},
-    scope::Scope,
-    state::SharedState,
+    state::{scope::Scope, SharedState},
     tn::TypeNotationChecker,
     types::Type,
 };

--- a/compiler/src/semantic/function.rs
+++ b/compiler/src/semantic/function.rs
@@ -217,11 +217,11 @@ mod tests {
     #[test]
     fn defining_duplicated_functions() {
         assert_is_err(indoc! {"
-                fn print_sum_of(a: Int, b: Int,) do
+                fn print_sum_of(a: int, b: int,) do
                     debug a + b;
                 end
 
-                fn print_sum_of(a: Float, b: Float) do
+                fn print_sum_of(a: float, b: float) do
                     debug a + b;
                 end
             "});
@@ -230,7 +230,7 @@ mod tests {
     #[test]
     fn defining_functions_both_with_parameters_and_return_type() {
         assert_is_ok(indoc! {"
-                fn sum(x: Int, y: Int): Int do
+                fn sum(x: int, y: int): int do
                     return x + y;
                 end
             "});
@@ -239,7 +239,7 @@ mod tests {
     #[test]
     fn recursive_fibonacci_function() {
         assert_is_ok(indoc! {"
-                fn fibonacci(n: Int): Int do
+                fn fibonacci(n: int): int do
                     if n == 0 do
                         return 0;
                     else if n == 1 || n == 2 do
@@ -253,7 +253,7 @@ mod tests {
     #[test]
     fn recursive_functions_with_void_return_type() {
         assert_is_ok(indoc! {"
-                fn count_to_zero(n: Int) do
+                fn count_to_zero(n: int) do
                     debug n;
                     if n == 0 do
                         return;
@@ -270,11 +270,11 @@ mod tests {
     #[test]
     fn returning_from_functions_with_conditional_and_loop_statements() {
         assert_is_ok(indoc! {"
-                fn first(): Int do
+                fn first(): int do
                     return 5;
                 end
 
-                fn second(): Int do
+                fn second(): int do
                     if false do
                         return 0;
                     else do
@@ -282,21 +282,21 @@ mod tests {
                     end
                 end
 
-                fn third(): Int do
+                fn third(): int do
                     if false do
                         return 0;
                     end
                     return 1;
                 end
 
-                fn fourth(): Int do
+                fn fourth(): int do
                     while false do
                         return 0;
                     end
                     return 1;
                 end
 
-                fn fifth(): Int do
+                fn fifth(): int do
                     return 1;
 
                     if false do
@@ -332,7 +332,7 @@ mod tests {
                     debug aliased();
                 end
 
-                fn return_two(): Int do
+                fn return_two(): int do
                     return 2;
                 end
             "});
@@ -345,11 +345,11 @@ mod tests {
                     debug get_num(produce);
                 end
 
-                fn get_num(producer: () -> Int): Int do
+                fn get_num(producer: () -> int): int do
                     return producer() + 5;
                 end
 
-                fn produce(): Int do
+                fn produce(): int do
                     return 10;
                 end
             "});
@@ -362,11 +362,11 @@ mod tests {
                     debug foo()();
                 end
 
-                fn foo(): () -> Int do
+                fn foo(): () -> int do
                     return bar;
                 end
 
-                fn bar(): Int do
+                fn bar(): int do
                     return 25;
                 end
             "});
@@ -379,7 +379,7 @@ mod tests {
                     foo([1, 2, 3]);
                 end
 
-                fn foo(arr: []Int) do
+                fn foo(arr: []int) do
                 end
             "});
     }
@@ -395,7 +395,7 @@ mod tests {
                     foo([1,]);
                 end
 
-                fn foo(arr: []Int) do
+                fn foo(arr: []int) do
                 end
             "});
     }
@@ -404,13 +404,13 @@ mod tests {
     fn returning_array_from_a_function() {
         assert_is_ok(indoc! {"
                 fn main() do
-                    var arr_1: []Int = foo();
-                    var arr_2: []Int = foo();
+                    var arr_1: []int = foo();
+                    var arr_2: []int = foo();
 
                     arr_1[0] = 10;
                 end
 
-                fn foo(): []Int do
+                fn foo(): []int do
                     return [1, 2, 3];
                 end
             "});
@@ -437,7 +437,7 @@ mod tests {
     #[test]
     fn defining_function_with_duplicated_parameter_name() {
         assert_is_err(indoc! {"
-                fn add_sum_of(x: Int, x: Int) do end
+                fn add_sum_of(x: int, x: int) do end
             "});
     }
 
@@ -467,7 +467,7 @@ mod tests {
     #[test]
     fn returning_value_from_function_with_mismatched_return_type() {
         assert_is_err(indoc! {"
-                fn sum(x: Int, y: Int): Int do
+                fn sum(x: int, y: int): int do
                     return 5.0;
                 end
             "});
@@ -476,7 +476,7 @@ mod tests {
     #[test]
     fn invalid_statement_after_return() {
         assert_is_err(indoc! {"
-                fn get_five(): Int do
+                fn get_five(): int do
                     return 5;
                     1 + true; # should be error
                 end
@@ -486,7 +486,7 @@ mod tests {
     #[test]
     fn returning_non_existing_variable() {
         assert_is_err(indoc! {"
-                fn foo(): Int do
+                fn foo(): int do
                     return not_exist;
                 end
             "});
@@ -495,7 +495,7 @@ mod tests {
     #[test]
     fn defining_function_with_missing_return_in_other_branches() {
         assert_is_err(indoc! {"
-                fn foo(): Int do
+                fn foo(): int do
                     if false do
                         return 5;
                     end
@@ -506,7 +506,7 @@ mod tests {
     #[test]
     fn defining_function_with_missing_return_in_else_branch_or_outer_scope() {
         assert_is_err(indoc! {"
-                fn foo(): Int do
+                fn foo(): int do
                     if false do
                         return 0;
                     else if !true do
@@ -519,7 +519,7 @@ mod tests {
     #[test]
     fn defining_function_with_missing_return_in_outer_scope_of_while_statement() {
         assert_is_err(indoc! {"
-                fn foo(): Int do
+                fn foo(): int do
                     while false do
                         return 0;
                     end

--- a/compiler/src/semantic/function.rs
+++ b/compiler/src/semantic/function.rs
@@ -63,7 +63,7 @@ impl FunctionDeclarationChecker<'_> {
     }
 
     fn return_t(&self) -> Type {
-        self.return_tn().map_or(Type::new("Void"), Type::from)
+        self.return_tn().map_or(Type::Void, Type::from)
     }
 
     // Save function information to the ScopeStack.
@@ -133,7 +133,7 @@ impl FunctionDefinitionChecker<'_> {
                 if !return_t.is_void() && body_t.is_void() {
                     return Err(Error::ReturnTypeMismatch {
                         expected: return_t,
-                        get: Type::new("Void"),
+                        get: Type::Void,
                         span: self.id().span().clone(),
                     });
                 }
@@ -141,7 +141,7 @@ impl FunctionDefinitionChecker<'_> {
                 Ok(())
             })?;
 
-        Ok(Type::new("Void"))
+        Ok(Type::Void)
     }
 
     fn save_params_to_stack(&self, params: &[((String, Span), Type)]) -> Result<()> {

--- a/compiler/src/semantic/literal.rs
+++ b/compiler/src/semantic/literal.rs
@@ -1,4 +1,9 @@
-use super::{error::Result, expression::ExpressionAnalyzer, state::SharedState, types::Type};
+use super::{
+    error::Result,
+    expression::ExpressionAnalyzer,
+    state::SharedState,
+    types::{LiteralType, Type},
+};
 use crate::ast::Literal;
 
 /// Analyzer for a literal expressions, such as numbers or arrays.
@@ -19,7 +24,7 @@ impl LiteralAnalyzer<'_> {
             Literal::Void => Ok(Type::Void),
             Literal::Bool(_) => Ok(Type::Bool),
 
-            Literal::Int(_) => Ok(Type::UIntLiteral),
+            Literal::Int(_) => Ok(Type::Literal(LiteralType::UnsignedInt)),
             Literal::Float(_) => Ok(Type::Float),
 
             Literal::Array(_) => self.analyze_array(),
@@ -79,7 +84,7 @@ impl LiteralAnalyzer<'_> {
 mod tests {
     use crate::semantic::{
         test_util::{assert_expression_is_err, assert_expression_type},
-        types::Type,
+        types::{LiteralType, Type},
     };
 
     #[test]
@@ -87,7 +92,7 @@ mod tests {
         assert_expression_type(
             "[1, 2, 3];",
             Type::Array {
-                elem_t: Some(Box::new(Type::UIntLiteral)),
+                elem_t: Some(Box::new(Type::Literal(LiteralType::UnsignedInt))),
             },
         );
     }
@@ -102,7 +107,7 @@ mod tests {
         assert_expression_type(
             "[8 * 2048];",
             Type::Array {
-                elem_t: Some(Box::new(Type::UIntLiteral)),
+                elem_t: Some(Box::new(Type::Literal(LiteralType::UnsignedInt))),
             },
         );
     }
@@ -113,7 +118,7 @@ mod tests {
             "[[1, 3, 5], [2, 6, 3], [9, 1, 1]];",
             Type::Array {
                 elem_t: Some(Box::new(Type::Array {
-                    elem_t: Some(Box::new(Type::UIntLiteral)),
+                    elem_t: Some(Box::new(Type::Literal(LiteralType::UnsignedInt))),
                 })),
             },
         );
@@ -130,7 +135,7 @@ mod tests {
             "[[], [1]];",
             Type::Array {
                 elem_t: Some(Box::new(Type::Array {
-                    elem_t: Some(Box::new(Type::UIntLiteral)),
+                    elem_t: Some(Box::new(Type::Literal(LiteralType::UnsignedInt))),
                 })),
             },
         );

--- a/compiler/src/semantic/literal.rs
+++ b/compiler/src/semantic/literal.rs
@@ -17,10 +17,10 @@ impl LiteralChecker<'_> {
     pub fn check(&self) -> Result<Type> {
         match self.lit {
             Literal::Void => Ok(Type::Void),
+            Literal::Bool(_) => Ok(Type::Bool),
 
-            Literal::Integer(_) => Ok(Type::UIntLiteral),
+            Literal::Int(_) => Ok(Type::UIntLiteral),
             Literal::Float(_) => Ok(Type::Float),
-            Literal::Boolean(_) => Ok(Type::Bool),
 
             Literal::Array(_) => self.check_array(),
         }

--- a/compiler/src/semantic/literal.rs
+++ b/compiler/src/semantic/literal.rs
@@ -16,10 +16,11 @@ impl<'a> LiteralChecker<'a> {
 impl LiteralChecker<'_> {
     pub fn check(&self) -> Result<Type> {
         match self.lit {
-            Literal::Void => Ok(Type::new("Void")),
+            Literal::Void => Ok(Type::Void),
+
             Literal::Integer(_) => Ok(Type::UIntLiteral),
-            Literal::Float(_) => Ok(Type::new("Float")),
-            Literal::Boolean(_) => Ok(Type::new("Bool")),
+            Literal::Float(_) => Ok(Type::Float),
+            Literal::Boolean(_) => Ok(Type::Bool),
 
             Literal::Array(_) => self.check_array(),
         }

--- a/compiler/src/semantic/literal.rs
+++ b/compiler/src/semantic/literal.rs
@@ -1,15 +1,15 @@
-use super::{error::Result, expression::ExpressionChecker, scope::ScopeStack, types::Type};
+use super::{error::Result, expression::ExpressionChecker, state::SharedState, types::Type};
 use crate::ast::Literal;
 
 /// Checker for a literal expressions, such as numbers or arrays.
 pub struct LiteralChecker<'a> {
-    ss: &'a ScopeStack,
     lit: &'a Literal,
+    state: &'a SharedState,
 }
 
 impl<'a> LiteralChecker<'a> {
-    pub const fn new(ss: &'a ScopeStack, lit: &'a Literal) -> Self {
-        Self { ss, lit }
+    pub const fn new(lit: &'a Literal, state: &'a SharedState) -> Self {
+        Self { lit, state }
     }
 }
 
@@ -53,7 +53,7 @@ impl LiteralChecker<'_> {
         let mut elem_t = None;
 
         for elem in arr {
-            let t = ExpressionChecker::new(self.ss, elem).check()?;
+            let t = ExpressionChecker::new(elem, self.state).check()?;
             if !t.is_array_with_unknown_elem_t() {
                 elem_t = Some(t);
                 break;
@@ -65,7 +65,7 @@ impl LiteralChecker<'_> {
         }
 
         for elem in arr {
-            let t = ExpressionChecker::new(self.ss, elem).check()?;
+            let t = ExpressionChecker::new(elem, self.state).check()?;
             Type::assert_assignable(&t, elem_t.as_ref().unwrap(), || elem.span().clone())?;
         }
 

--- a/compiler/src/semantic/literal.rs
+++ b/compiler/src/semantic/literal.rs
@@ -21,11 +21,11 @@ impl<'a> LiteralAnalyzer<'a> {
 impl LiteralAnalyzer<'_> {
     pub fn analyze(&self) -> Result<Type> {
         match self.lit {
-            Literal::Void => Ok(Type::Void),
-            Literal::Bool(_) => Ok(Type::Bool),
+            Literal::Void => Ok(Type::void()),
+            Literal::Bool(_) => Ok(Type::bool()),
 
             Literal::Int(_) => Ok(Type::Literal(LiteralType::UnsignedInt)),
-            Literal::Float(_) => Ok(Type::Float),
+            Literal::Float(_) => Ok(Type::float()),
 
             Literal::Array(_) => self.analyze_array(),
         }

--- a/compiler/src/semantic/literal.rs
+++ b/compiler/src/semantic/literal.rs
@@ -17,7 +17,7 @@ impl LiteralChecker<'_> {
     pub fn check(&self) -> Result<Type> {
         match self.lit {
             Literal::Void => Ok(Type::new("Void")),
-            Literal::Integer(_) => Ok(Type::new("Int")),
+            Literal::Integer(_) => Ok(Type::UIntLiteral),
             Literal::Float(_) => Ok(Type::new("Float")),
             Literal::Boolean(_) => Ok(Type::new("Bool")),
 
@@ -86,7 +86,7 @@ mod tests {
         assert_expression_type(
             "[1, 2, 3];",
             Type::Array {
-                elem_t: Some(Box::new(Type::new("Int"))),
+                elem_t: Some(Box::new(Type::UIntLiteral)),
             },
         );
     }
@@ -101,7 +101,7 @@ mod tests {
         assert_expression_type(
             "[8 * 2048];",
             Type::Array {
-                elem_t: Some(Box::new(Type::new("Int"))),
+                elem_t: Some(Box::new(Type::UIntLiteral)),
             },
         );
     }
@@ -112,7 +112,7 @@ mod tests {
             "[[1, 3, 5], [2, 6, 3], [9, 1, 1]];",
             Type::Array {
                 elem_t: Some(Box::new(Type::Array {
-                    elem_t: Some(Box::new(Type::new("Int"))),
+                    elem_t: Some(Box::new(Type::UIntLiteral)),
                 })),
             },
         );
@@ -129,7 +129,7 @@ mod tests {
             "[[], [1]];",
             Type::Array {
                 elem_t: Some(Box::new(Type::Array {
-                    elem_t: Some(Box::new(Type::new("Int"))),
+                    elem_t: Some(Box::new(Type::UIntLiteral)),
                 })),
             },
         );

--- a/compiler/src/semantic/scope.rs
+++ b/compiler/src/semantic/scope.rs
@@ -119,12 +119,7 @@ impl Scope {
     pub fn new_builtin_scope() -> Self {
         Self {
             symbols: HashMap::new(),
-            types: HashSet::from([
-                Type::new("Void"),
-                Type::new("Int"),
-                Type::new("Float"),
-                Type::new("Bool"),
-            ]),
+            types: HashSet::from([Type::Void, Type::Int, Type::Float, Type::Bool]),
             scope_t: ScopeType::Builtin,
         }
     }

--- a/compiler/src/semantic/state.rs
+++ b/compiler/src/semantic/state.rs
@@ -1,4 +1,6 @@
-use super::scope::ScopeStack;
+use scope::ScopeStack;
+
+pub mod scope;
 
 #[derive(Default)]
 pub struct SharedState {

--- a/compiler/src/semantic/state.rs
+++ b/compiler/src/semantic/state.rs
@@ -21,7 +21,9 @@ impl SharedState {
     /// Creates a new [`SharedState`] instance.
     pub fn new() -> Self {
         let st = SymTable::new();
-        let current_scope = Rc::downgrade(&st.root);
+
+        // Initialize current active scope to global
+        let current_scope = Rc::downgrade(&st.root.as_ref().borrow().children[0]);
 
         Self {
             st,

--- a/compiler/src/semantic/state.rs
+++ b/compiler/src/semantic/state.rs
@@ -1,0 +1,6 @@
+use super::scope::ScopeStack;
+
+#[derive(Default)]
+pub struct SharedState {
+    pub ss: ScopeStack,
+}

--- a/compiler/src/semantic/state.rs
+++ b/compiler/src/semantic/state.rs
@@ -11,7 +11,7 @@ pub mod symtable;
 
 /// Contains data that is shared across multiple analyzers.
 pub struct SharedState {
-    pub _st: SymTable,
+    st: SymTable,
 
     // Current active scope
     current_scope: RefCell<WeakScopeRef>,
@@ -24,9 +24,13 @@ impl SharedState {
         let current_scope = Rc::downgrade(&st.root);
 
         Self {
-            _st: st,
+            st,
             current_scope: RefCell::new(current_scope),
         }
+    }
+
+    pub fn take_st(self) -> SymTable {
+        self.st
     }
 
     /// Get the type associated with a `sym` in the current active scope or its

--- a/compiler/src/semantic/state.rs
+++ b/compiler/src/semantic/state.rs
@@ -1,8 +1,109 @@
-use scope::ScopeStack;
+use super::{
+    error::{Error, Result},
+    types::Type,
+};
+use scope::{Scope, ScopeVariant, WeakScopeRef};
+use std::{cell::RefCell, rc::Rc};
+use symtable::SymTable;
 
 pub mod scope;
+pub mod symtable;
 
-#[derive(Default)]
+/// Contains data that is shared across multiple analyzers.
 pub struct SharedState {
-    pub ss: ScopeStack,
+    pub _st: SymTable,
+
+    // Current active scope
+    current_scope: RefCell<WeakScopeRef>,
+}
+
+impl SharedState {
+    /// Creates a new [`SharedState`] instance.
+    pub fn new() -> Self {
+        let st = SymTable::new();
+        let current_scope = Rc::downgrade(&st.root);
+
+        Self {
+            _st: st,
+            current_scope: RefCell::new(current_scope),
+        }
+    }
+
+    /// Get the type associated with a `sym` in the current active scope or its
+    /// ancestors.
+    pub fn get_sym_t(&self, sym: &str) -> Option<Type> {
+        let current_scope = self.current_scope.borrow().upgrade().unwrap();
+        SymTable::get_sym_t(sym, &current_scope)
+    }
+
+    /// Check if a type exists in the current active scope or its ancestors.
+    pub fn has_t(&self, t: &Type) -> bool {
+        if let Type::Callable { params_t, return_t } = t {
+            return params_t.iter().all(|t| self.has_t(t)) && self.has_t(return_t);
+        }
+
+        if let Type::Array { elem_t } = t {
+            return self.has_t(elem_t.as_ref().unwrap());
+        }
+
+        let current_scope = self.current_scope.borrow().upgrade().unwrap();
+        SymTable::has_t(t, &current_scope)
+    }
+
+    /// Get the return type of nearest function ancestor.
+    ///
+    /// Returns `None` if no function can be found.
+    pub fn nearest_return_t(&self) -> Option<Type> {
+        let current_scope = self.current_scope.borrow().upgrade().unwrap();
+        SymTable::nearest_return_t(&current_scope)
+    }
+
+    /// Check if the current active scope is a loop or contained within a loop
+    /// scope ancestor.
+    pub fn is_inside_loop(&self) -> bool {
+        let current_scope = self.current_scope.borrow().upgrade().unwrap();
+        SymTable::is_inside_loop(&current_scope)
+    }
+
+    /// Save symbol and its associated type to current active scope.
+    ///
+    /// If symbol is already exist in the scope, it will run the `err` closure.
+    pub fn save_sym_or_else<F>(&self, sym: &str, t: Type, err: F) -> Result<()>
+    where
+        F: FnOnce() -> Error,
+    {
+        let current_scope = self.current_scope.borrow().upgrade().unwrap();
+        let mut scope = current_scope.as_ref().borrow_mut();
+
+        if scope.has_sym(sym) {
+            return Err(err());
+        }
+
+        scope.save_sym(sym, t);
+
+        Ok(())
+    }
+
+    /// Execute `action` within a scope of `variant` variant.
+    ///
+    /// It automatically handles the creating and exiting of the new scope.
+    pub fn with_scope<U, F>(&self, variant: ScopeVariant, action: F) -> U
+    where
+        F: FnOnce() -> U,
+    {
+        let parent = self.current_scope.borrow().upgrade().unwrap();
+        let child = Scope::new(variant);
+
+        SymTable::add_scope(&parent, child.clone());
+
+        // Entering child scope
+        *self.current_scope.borrow_mut() = Rc::downgrade(&child);
+
+        let result = action();
+
+        // Exiting child scope
+        *self.current_scope.borrow_mut() = Rc::downgrade(&parent);
+
+        result
+    }
 }

--- a/compiler/src/semantic/state/scope.rs
+++ b/compiler/src/semantic/state/scope.rs
@@ -1,4 +1,4 @@
-use super::{
+use crate::semantic::{
     error::{Error, Result},
     types::Type,
 };

--- a/compiler/src/semantic/state/symtable.rs
+++ b/compiler/src/semantic/state/symtable.rs
@@ -24,10 +24,10 @@ impl SymTable {
     /// `Type::Int`).
     pub fn new() -> Self {
         let builtin = Scope::new(ScopeVariant::Builtin);
-        builtin.borrow_mut().add_t(Type::Void);
-        builtin.borrow_mut().add_t(Type::Int);
-        builtin.borrow_mut().add_t(Type::Float);
-        builtin.borrow_mut().add_t(Type::Bool);
+        builtin.borrow_mut().add_t(Type::void());
+        builtin.borrow_mut().add_t(Type::int());
+        builtin.borrow_mut().add_t(Type::float());
+        builtin.borrow_mut().add_t(Type::bool());
 
         let global = Scope::new(ScopeVariant::Global);
 

--- a/compiler/src/semantic/state/symtable.rs
+++ b/compiler/src/semantic/state/symtable.rs
@@ -1,0 +1,141 @@
+use super::scope::{Scope, ScopeRef, ScopeVariant};
+use crate::semantic::types::Type;
+use std::rc::Rc;
+
+/// SymTable implements the [symbol table](https://en.wikipedia.org/wiki/Symbol_table)
+/// of a Kaba program.
+///
+/// It uses a tree data structure to store [`Scope`] alongside their associated
+/// symbols and [`Type`].
+///
+/// It is constructed during the semantic analysist and will be accessed again
+/// on later phase(s), such as during IR code generation.
+#[derive(Debug)]
+pub struct SymTable {
+    pub root: ScopeRef,
+}
+
+impl SymTable {
+    /// Create a new [`SymTable`] instance with some [`Scope`] already included.
+    ///
+    /// The newly created instance contains the `ScopeVariant::Builtin` and
+    /// `ScopeVariant::Global` variants, with some builtin [`Type`] included
+    /// in the `ScopeVariant::Builtin` (such as the `Type::Void` and
+    /// `Type::Int`).
+    pub fn new() -> Self {
+        let builtin = Scope::new(ScopeVariant::Builtin);
+        builtin.borrow_mut().add_t(Type::Void);
+        builtin.borrow_mut().add_t(Type::Int);
+        builtin.borrow_mut().add_t(Type::Float);
+        builtin.borrow_mut().add_t(Type::Bool);
+
+        let global = Scope::new(ScopeVariant::Global);
+
+        SymTable::add_scope(&builtin, global);
+
+        Self { root: builtin }
+    }
+
+    /// Attach a new scope to a parent scope as its child.
+    pub fn add_scope(parent: &ScopeRef, child: ScopeRef) {
+        child.borrow_mut().parent = Some(Rc::downgrade(parent));
+
+        parent.borrow_mut().children.push(child);
+    }
+
+    /// Get the [`Type`] stored under `sym` key.
+    ///
+    /// It first will check inside the scope pointed by `start_from` reference,
+    /// and will walk upward (traversing the ancestors) until the symbol is
+    /// found.
+    ///
+    /// If it has reached the root scope (`ScopeVariant::Builtin`) but still
+    /// unable to find the symbol, it will return `None` instead.
+    pub fn get_sym_t(sym: &str, start_from: &ScopeRef) -> Option<Type> {
+        let mut current = Some(Rc::clone(start_from));
+
+        while let Some(scope) = current {
+            if scope.as_ref().borrow().has_sym(sym) {
+                return Some(scope.as_ref().borrow().get_sym_t(sym));
+            }
+
+            current = scope
+                .as_ref()
+                .borrow()
+                .parent
+                .as_ref()
+                .and_then(|p| p.upgrade());
+        }
+
+        None
+    }
+
+    /// Check if the scope pointed by `start_from` reference (and its ancestors)
+    /// contains type `t`.
+    pub fn has_t(t: &Type, start_from: &ScopeRef) -> bool {
+        let mut current = Some(Rc::clone(start_from));
+
+        while let Some(scope) = current {
+            if scope.as_ref().borrow().has_t(t) {
+                return true;
+            }
+
+            current = scope
+                .as_ref()
+                .borrow()
+                .parent
+                .as_ref()
+                .and_then(|p| p.upgrade());
+        }
+
+        false
+    }
+
+    /// Get the return type of nearest function scope (`ScopeVariant::Function`)
+    /// ancestor.
+    ///
+    /// It will returns `None` if no function scope can be found until it has
+    /// reached the root.
+    pub fn nearest_return_t(start_from: &ScopeRef) -> Option<Type> {
+        let mut current = Some(Rc::clone(start_from));
+
+        while let Some(scope) = current {
+            if scope.as_ref().borrow().is_function() {
+                return Some(scope.as_ref().borrow().function_return_t());
+            }
+
+            current = scope
+                .as_ref()
+                .borrow()
+                .parent
+                .as_ref()
+                .and_then(|p| p.upgrade());
+        }
+
+        None
+    }
+
+    /// Check if the scope referenced by `start_from` is contained within a
+    /// loop.
+    ///
+    /// That is, check if there is a `ScopeVariant::Loop` in one of the scope's
+    /// ancestors.
+    pub fn is_inside_loop(start_from: &ScopeRef) -> bool {
+        let mut current = Some(Rc::clone(start_from));
+
+        while let Some(scope) = current {
+            if scope.as_ref().borrow().is_loop() {
+                return true;
+            }
+
+            current = scope
+                .as_ref()
+                .borrow()
+                .parent
+                .as_ref()
+                .and_then(|p| p.upgrade());
+        }
+
+        false
+    }
+}

--- a/compiler/src/semantic/statement.rs
+++ b/compiler/src/semantic/statement.rs
@@ -62,14 +62,14 @@ impl StatementAnalyzer<'_> {
             });
         }
 
-        Ok(Type::Void)
+        Ok(Type::void())
     }
 
     fn analyze_return(&self, expr: &Option<Box<AstNode>>, span: &Span) -> Result<Type> {
         let expr_t = expr
             .as_ref()
             .map(|expr| ExpressionAnalyzer::new(expr, self.state).analyze())
-            .unwrap_or(Ok(Type::Void))?;
+            .unwrap_or(Ok(Type::void()))?;
 
         let return_t = self
             .state
@@ -94,7 +94,7 @@ impl StatementAnalyzer<'_> {
             return Err(Error::UnexpectedVoidTypeExpression { span: span.clone() });
         }
 
-        Ok(Type::Void)
+        Ok(Type::void())
     }
 }
 

--- a/compiler/src/semantic/statement.rs
+++ b/compiler/src/semantic/statement.rs
@@ -62,14 +62,14 @@ impl StatementChecker<'_> {
             });
         }
 
-        Ok(Type::new("Void"))
+        Ok(Type::Void)
     }
 
     fn check_return(&self, expr: &Option<Box<AstNode>>, span: &Span) -> Result<Type> {
         let expr_t = expr
             .as_ref()
             .map(|expr| ExpressionChecker::new(self.ss, expr).check())
-            .unwrap_or(Ok(Type::new("Void")))?;
+            .unwrap_or(Ok(Type::Void))?;
 
         let return_t =
             self.ss
@@ -94,7 +94,7 @@ impl StatementChecker<'_> {
             return Err(Error::UnexpectedVoidTypeExpression { span: span.clone() });
         }
 
-        Ok(Type::new("Void"))
+        Ok(Type::Void)
     }
 }
 

--- a/compiler/src/semantic/statement.rs
+++ b/compiler/src/semantic/statement.rs
@@ -55,7 +55,7 @@ impl StatementChecker<'_> {
     }
 
     fn check_loop_control(&self, span: &Span) -> Result<Type> {
-        if !self.state.ss.is_inside_loop() {
+        if !self.state.is_inside_loop() {
             return Err(Error::UnexpectedStatement {
                 stmt_str: self.node.to_string(),
                 span: span.clone(),
@@ -71,12 +71,13 @@ impl StatementChecker<'_> {
             .map(|expr| ExpressionChecker::new(expr, self.state).check())
             .unwrap_or(Ok(Type::Void))?;
 
-        let return_t = self.state.ss.current_function_return_t().ok_or_else(|| {
-            Error::UnexpectedStatement {
+        let return_t = self
+            .state
+            .nearest_return_t()
+            .ok_or_else(|| Error::UnexpectedStatement {
                 stmt_str: self.node.to_string(),
                 span: span.clone(),
-            }
-        })?;
+            })?;
 
         Type::assert_assignable(&expr_t, &return_t, || span.clone())
             .map_err(|err| Error::ReturnTypeMismatch {

--- a/compiler/src/semantic/test_util.rs
+++ b/compiler/src/semantic/test_util.rs
@@ -27,7 +27,7 @@ pub fn assert_expression_type(input: &str, expected_t: Type) {
     let tokens = lexer::lex(input).unwrap();
     let ast = parser::parse(tokens).unwrap();
 
-    let result = if let AstNode::Program { body } = &ast {
+    let result = if let AstNode::Program { body, .. } = &ast {
         let scopes = ScopeStack::default();
         ExpressionChecker::new(&scopes, &body[0]).check()
     } else {
@@ -42,7 +42,7 @@ pub fn assert_expression_is_err(input: &str) {
     let tokens = lexer::lex(input).unwrap();
     let ast = parser::parse(tokens).unwrap();
 
-    let result = if let AstNode::Program { body } = &ast {
+    let result = if let AstNode::Program { body, .. } = &ast {
         let scopes = ScopeStack::default();
         ExpressionChecker::new(&scopes, &body[0]).check()
     } else {

--- a/compiler/src/semantic/test_util.rs
+++ b/compiler/src/semantic/test_util.rs
@@ -2,14 +2,14 @@ use super::types::Type;
 use crate::{
     ast::AstNode,
     lexer, parser,
-    semantic::{expression::ExpressionChecker, state::SharedState, ProgramChecker},
+    semantic::{expression::ExpressionAnalyzer, state::SharedState, ProgramAnalyzer},
 };
 
 pub fn assert_is_ok(input: &str) {
     let tokens = lexer::lex(input).unwrap();
     let ast = parser::parse(tokens).unwrap();
 
-    let result = ProgramChecker::new(&ast).check();
+    let result = ProgramAnalyzer::new(&ast).analyze();
 
     assert!(result.is_ok());
 }
@@ -18,7 +18,7 @@ pub fn assert_is_err(input: &str) {
     let tokens = lexer::lex(input).unwrap();
     let ast = parser::parse(tokens).unwrap();
 
-    let result = ProgramChecker::new(&ast).check();
+    let result = ProgramAnalyzer::new(&ast).analyze();
 
     assert!(result.is_err());
 }
@@ -29,7 +29,7 @@ pub fn assert_expression_type(input: &str, expected_t: Type) {
 
     let result = if let AstNode::Program { body, .. } = &ast {
         let state = SharedState::new();
-        ExpressionChecker::new(&body[0], &state).check()
+        ExpressionAnalyzer::new(&body[0], &state).analyze()
     } else {
         unreachable!();
     };
@@ -44,7 +44,7 @@ pub fn assert_expression_is_err(input: &str) {
 
     let result = if let AstNode::Program { body, .. } = &ast {
         let state = SharedState::new();
-        ExpressionChecker::new(&body[0], &state).check()
+        ExpressionAnalyzer::new(&body[0], &state).analyze()
     } else {
         unreachable!();
     };

--- a/compiler/src/semantic/test_util.rs
+++ b/compiler/src/semantic/test_util.rs
@@ -28,7 +28,7 @@ pub fn assert_expression_type(input: &str, expected_t: Type) {
     let ast = parser::parse(tokens).unwrap();
 
     let result = if let AstNode::Program { body, .. } = &ast {
-        let state = SharedState::default();
+        let state = SharedState::new();
         ExpressionChecker::new(&body[0], &state).check()
     } else {
         unreachable!();
@@ -43,7 +43,7 @@ pub fn assert_expression_is_err(input: &str) {
     let ast = parser::parse(tokens).unwrap();
 
     let result = if let AstNode::Program { body, .. } = &ast {
-        let state = SharedState::default();
+        let state = SharedState::new();
         ExpressionChecker::new(&body[0], &state).check()
     } else {
         unreachable!();

--- a/compiler/src/semantic/test_util.rs
+++ b/compiler/src/semantic/test_util.rs
@@ -2,7 +2,7 @@ use super::types::Type;
 use crate::{
     ast::AstNode,
     lexer, parser,
-    semantic::{expression::ExpressionChecker, scope::ScopeStack, ProgramChecker},
+    semantic::{expression::ExpressionChecker, state::SharedState, ProgramChecker},
 };
 
 pub fn assert_is_ok(input: &str) {
@@ -28,8 +28,8 @@ pub fn assert_expression_type(input: &str, expected_t: Type) {
     let ast = parser::parse(tokens).unwrap();
 
     let result = if let AstNode::Program { body, .. } = &ast {
-        let scopes = ScopeStack::default();
-        ExpressionChecker::new(&scopes, &body[0]).check()
+        let state = SharedState::default();
+        ExpressionChecker::new(&body[0], &state).check()
     } else {
         unreachable!();
     };
@@ -43,8 +43,8 @@ pub fn assert_expression_is_err(input: &str) {
     let ast = parser::parse(tokens).unwrap();
 
     let result = if let AstNode::Program { body, .. } = &ast {
-        let scopes = ScopeStack::default();
-        ExpressionChecker::new(&scopes, &body[0]).check()
+        let state = SharedState::default();
+        ExpressionChecker::new(&body[0], &state).check()
     } else {
         unreachable!();
     };

--- a/compiler/src/semantic/tn.rs
+++ b/compiler/src/semantic/tn.rs
@@ -6,14 +6,14 @@ use super::{
 use crate::ast::AstNode;
 use logos::Span;
 
-pub struct TypeNotationChecker<'a> {
+pub struct TypeNotationAnalyzer<'a> {
     node: &'a AstNode,
     state: &'a SharedState,
 
     void_allowed: bool,
 }
 
-impl<'a> TypeNotationChecker<'a> {
+impl<'a> TypeNotationAnalyzer<'a> {
     pub const fn new(node: &'a AstNode, state: &'a SharedState) -> Self {
         Self {
             node,
@@ -28,8 +28,8 @@ impl<'a> TypeNotationChecker<'a> {
     }
 }
 
-impl TypeNotationChecker<'_> {
-    pub fn check(&self) -> Result<Type> {
+impl TypeNotationAnalyzer<'_> {
+    pub fn analyze(&self) -> Result<Type> {
         // The provided type must exist in the current scope
         if !self.state.has_t(&self.t()) {
             return Err(Error::SymbolDoesNotExist {

--- a/compiler/src/semantic/tn.rs
+++ b/compiler/src/semantic/tn.rs
@@ -1,23 +1,23 @@
 use super::{
     error::{Error, Result},
-    scope::ScopeStack,
+    state::SharedState,
     types::Type,
 };
 use crate::ast::AstNode;
 use logos::Span;
 
 pub struct TypeNotationChecker<'a> {
-    ss: &'a ScopeStack,
     node: &'a AstNode,
+    state: &'a SharedState,
 
     void_allowed: bool,
 }
 
 impl<'a> TypeNotationChecker<'a> {
-    pub const fn new(ss: &'a ScopeStack, node: &'a AstNode) -> Self {
+    pub const fn new(node: &'a AstNode, state: &'a SharedState) -> Self {
         Self {
-            ss,
             node,
+            state,
             void_allowed: false,
         }
     }
@@ -31,7 +31,7 @@ impl<'a> TypeNotationChecker<'a> {
 impl TypeNotationChecker<'_> {
     pub fn check(&self) -> Result<Type> {
         // The provided type must exist in the current scope
-        if !self.ss.has_t(&self.t()) {
+        if !self.state.ss.has_t(&self.t()) {
             return Err(Error::SymbolDoesNotExist {
                 id: self.t().to_string(),
                 span: self.span().clone(),

--- a/compiler/src/semantic/tn.rs
+++ b/compiler/src/semantic/tn.rs
@@ -31,7 +31,7 @@ impl<'a> TypeNotationChecker<'a> {
 impl TypeNotationChecker<'_> {
     pub fn check(&self) -> Result<Type> {
         // The provided type must exist in the current scope
-        if !self.state.ss.has_t(&self.t()) {
+        if !self.state.has_t(&self.t()) {
             return Err(Error::SymbolDoesNotExist {
                 id: self.t().to_string(),
                 span: self.span().clone(),

--- a/compiler/src/semantic/types.rs
+++ b/compiler/src/semantic/types.rs
@@ -159,7 +159,7 @@ impl Type {
         [Self::UInt, Self::Int, Self::Float].contains(self) || self.is_number_literal()
     }
 
-    pub fn is_boolean(&self) -> bool {
+    pub const fn is_boolean(&self) -> bool {
         matches!(self, Self::Bool)
     }
 
@@ -205,8 +205,20 @@ impl Type {
         self == &Type::UIntLiteral && [Type::Int, Type::IntLiteral].contains(target)
     }
 
-    pub fn is_void(&self) -> bool {
+    pub const fn is_void(&self) -> bool {
         matches!(self, Self::Void)
+    }
+
+    pub fn morph_default(&self) -> Type {
+        match self {
+            Self::UIntLiteral | Self::IntLiteral => Self::Int,
+
+            Self::Array { elem_t } => Self::Array {
+                elem_t: elem_t.as_ref().map(|t| Box::new(t.morph_default())),
+            },
+
+            t => t.clone(),
+        }
     }
 
     pub fn unwrap_array(&self) -> &Option<Box<Type>> {

--- a/compiler/src/semantic/types.rs
+++ b/compiler/src/semantic/types.rs
@@ -5,14 +5,6 @@ use std::fmt::Display;
 
 #[derive(Clone, Debug, Eq, Ord, Hash, PartialEq, PartialOrd)]
 pub enum Type {
-    Void,
-    Bool,
-
-    UInt,
-    Int,
-
-    Float,
-
     // We specifically differentiate the type of literals to accommodate their
     // assignment into various types.
     //
@@ -146,8 +138,28 @@ impl Type {
         }
     }
 
+    pub fn void() -> Type {
+        Type::Identifier(String::from("void"))
+    }
+
+    pub fn bool() -> Type {
+        Type::Identifier(String::from("bool"))
+    }
+
+    pub fn uint() -> Type {
+        Type::Identifier(String::from("uint"))
+    }
+
+    pub fn int() -> Type {
+        Type::Identifier(String::from("int"))
+    }
+
+    pub fn float() -> Type {
+        Type::Identifier(String::from("float"))
+    }
+
     pub fn is_number(&self) -> bool {
-        [Self::UInt, Self::Int, Self::Float].contains(self) || self.is_number_literal()
+        [Self::uint(), Self::int(), Self::float()].contains(self) || self.is_number_literal()
     }
 
     pub fn is_number_literal(&self) -> bool {
@@ -156,11 +168,11 @@ impl Type {
     }
 
     fn is_signable_number(&self) -> bool {
-        [Self::UInt, Self::Int, Self::Float].contains(self) || self.is_number_literal()
+        [Self::uint(), Self::int(), Self::float()].contains(self) || self.is_number_literal()
     }
 
-    pub const fn is_boolean(&self) -> bool {
-        matches!(self, Self::Bool)
+    pub fn is_boolean(&self) -> bool {
+        self == &Self::bool()
     }
 
     pub const fn is_array(&self) -> bool {
@@ -202,17 +214,19 @@ impl Type {
     // For example, unsigned integer literals are morphable into `Byte`,
     // `Short`, `Int`, etc.
     fn is_morphable_to(&self, target: &Type) -> bool {
-        self == &Type::Literal(LiteralType::UnsignedInt)
-            && [Type::Int, Type::Literal(LiteralType::Int)].contains(target)
+        self == &Self::Literal(LiteralType::UnsignedInt)
+            && [Self::int(), Self::Literal(LiteralType::Int)].contains(target)
     }
 
-    pub const fn is_void(&self) -> bool {
-        matches!(self, Self::Void)
+    pub fn is_void(&self) -> bool {
+        self == &Self::void()
     }
 
     pub fn morph_default(&self) -> Type {
         match self {
-            Type::Literal(LiteralType::UnsignedInt) | Type::Literal(LiteralType::Int) => Self::Int,
+            Type::Literal(LiteralType::UnsignedInt) | Type::Literal(LiteralType::Int) => {
+                Self::int()
+            }
 
             Self::Array { elem_t } => Self::Array {
                 elem_t: elem_t.as_ref().map(|t| Box::new(t.morph_default())),
@@ -243,14 +257,6 @@ impl<'a> From<&'a AstNode> for Type {
     fn from(value: &'a AstNode) -> Self {
         if let AstNode::TypeNotation { tn, .. } = value {
             match tn {
-                TypeNotation::Identifier(id) if id == "void" => Self::Void,
-                TypeNotation::Identifier(id) if id == "bool" => Self::Bool,
-
-                TypeNotation::Identifier(id) if id == "uint" => Self::UInt,
-                TypeNotation::Identifier(id) if id == "int" => Self::Int,
-
-                TypeNotation::Identifier(id) if id == "float" => Self::Float,
-
                 TypeNotation::Identifier(id) => Self::Identifier(id.to_string()),
 
                 TypeNotation::Array { elem_tn } => Self::Array {
@@ -278,14 +284,6 @@ impl<'a> From<&'a AstNode> for Type {
 impl Display for Type {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Void => write!(f, "void"),
-            Self::Bool => write!(f, "bool"),
-
-            Self::UInt => write!(f, "uint"),
-            Self::Int => write!(f, "int"),
-
-            Self::Float => write!(f, "float"),
-
             Self::Literal(LiteralType::UnsignedInt) => write!(f, "uint"),
             Self::Literal(LiteralType::Int) => write!(f, "int"),
 

--- a/compiler/src/semantic/types.rs
+++ b/compiler/src/semantic/types.rs
@@ -18,11 +18,11 @@ pub enum Type {
     //
     // For example, both assignments are valid:
     //
-    //      var x: Byte = 16;
-    //      var y: Int = 16;
+    //      var x: byte = 16;
+    //      var y: int = 16;
     //
-    // If the `16` is Self::Identifier("Int"), then the assignment into the
-    // `Byte` type variable should results in error. We want to avoid that.
+    // If the `16` is inferred as `uint`, then the assignment into the `byte`
+    // type variable should results in error (undesired behaviour).
     Literal(LiteralType),
 
     Identifier(String),
@@ -243,13 +243,13 @@ impl<'a> From<&'a AstNode> for Type {
     fn from(value: &'a AstNode) -> Self {
         if let AstNode::TypeNotation { tn, .. } = value {
             match tn {
-                TypeNotation::Identifier(id) if id == "Void" => Self::Void,
-                TypeNotation::Identifier(id) if id == "Bool" => Self::Bool,
+                TypeNotation::Identifier(id) if id == "void" => Self::Void,
+                TypeNotation::Identifier(id) if id == "bool" => Self::Bool,
 
-                TypeNotation::Identifier(id) if id == "UInt" => Self::UInt,
-                TypeNotation::Identifier(id) if id == "Int" => Self::Int,
+                TypeNotation::Identifier(id) if id == "uint" => Self::UInt,
+                TypeNotation::Identifier(id) if id == "int" => Self::Int,
 
-                TypeNotation::Identifier(id) if id == "Float" => Self::Float,
+                TypeNotation::Identifier(id) if id == "float" => Self::Float,
 
                 TypeNotation::Identifier(id) => Self::Identifier(id.to_string()),
 
@@ -278,16 +278,16 @@ impl<'a> From<&'a AstNode> for Type {
 impl Display for Type {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Void => write!(f, "Void"),
-            Self::Bool => write!(f, "Bool"),
+            Self::Void => write!(f, "void"),
+            Self::Bool => write!(f, "bool"),
 
-            Self::UInt => write!(f, "UInt"),
-            Self::Int => write!(f, "Int"),
+            Self::UInt => write!(f, "uint"),
+            Self::Int => write!(f, "int"),
 
-            Self::Float => write!(f, "Float"),
+            Self::Float => write!(f, "float"),
 
-            Self::Literal(LiteralType::UnsignedInt) => write!(f, "UInt"),
-            Self::Literal(LiteralType::Int) => write!(f, "Int"),
+            Self::Literal(LiteralType::UnsignedInt) => write!(f, "uint"),
+            Self::Literal(LiteralType::Int) => write!(f, "int"),
 
             Self::Identifier(id) => write!(f, "{id}"),
 

--- a/compiler/src/semantic/variable.rs
+++ b/compiler/src/semantic/variable.rs
@@ -121,8 +121,7 @@ impl VariableDeclarationChecker<'_> {
 
     fn save_symbol(&self, id: &str, t: Type, span: &Span) -> Result<()> {
         self.state
-            .ss
-            .save_symbol_or_else(id, t, || Error::SymbolAlreadyExist {
+            .save_sym_or_else(id, t, || Error::SymbolAlreadyExist {
                 id: String::from(id),
                 span: span.clone(),
             })

--- a/compiler/src/semantic/variable.rs
+++ b/compiler/src/semantic/variable.rs
@@ -67,7 +67,7 @@ impl VariableDeclarationChecker<'_> {
 
         self.save_symbol(&self.id_string(), var_t.unwrap_or(val_t), self.span())?;
 
-        Ok(Type::new("Void"))
+        Ok(Type::Void)
     }
 
     fn check_tn(&self, tn: &AstNode, val_t: &Type) -> Result<Type> {

--- a/compiler/src/semantic/variable.rs
+++ b/compiler/src/semantic/variable.rs
@@ -66,7 +66,7 @@ impl VariableDeclarationAnalyzer<'_> {
 
         self.save_symbol(&self.id_string(), var_t, self.span())?;
 
-        Ok(Type::Void)
+        Ok(Type::void())
     }
 
     fn analyze_tn(&self, tn: &AstNode, val_t: &Type) -> Result<Type> {

--- a/compiler/src/semantic/variable.rs
+++ b/compiler/src/semantic/variable.rs
@@ -15,7 +15,7 @@ use logos::Span;
 /// * Below is the example of a valid, full-form variable declaration:
 ///
 /// ```text
-/// var x: Int = 5;
+/// var x: int = 5;
 /// ```
 ///
 /// * The type can also be inferred:
@@ -29,14 +29,14 @@ use logos::Span;
 /// * Variable can't be created without providing the initial value:
 ///
 /// ```text
-/// var x: Int;
+/// var x: int;
 /// ```
 ///
 /// * If type notation presents, the provided initial value must also be
 ///   assignable to the type:
 ///
 /// ```text
-/// var x: Int = 5.0;
+/// var x: int = 5.0;
 /// ```
 pub struct VariableDeclarationAnalyzer<'a> {
     node: &'a AstNode,
@@ -136,7 +136,7 @@ mod tests {
     fn declaring_variable_with_type_annotation_and_initial_value() {
         assert_is_ok(indoc! {"
                 fn main() do
-                    var x: Int = 5;
+                    var x: int = 5;
                 end
             "});
     }
@@ -181,7 +181,7 @@ mod tests {
     fn declaring_variable_with_incompatible_type() {
         assert_is_err(indoc! {"
                 fn main() do
-                    var x: Int = 5.0;
+                    var x: int = 5.0;
                 end
             "})
     }
@@ -213,12 +213,12 @@ mod tests {
     fn declaring_variable_with_function_pointer_as_value() {
         assert_is_ok(indoc! {"
                 fn main() do
-                    var x: () -> Int = produce;
+                    var x: () -> int = produce;
 
                     debug x();
                 end
 
-                fn produce(): Int do
+                fn produce(): int do
                     return 5;
                 end
             "});
@@ -272,7 +272,7 @@ mod tests {
     fn declaring_variable_with_array_type_notation() {
         assert_is_ok(indoc! {"
                 fn main() do
-                    var arr: []Int = [5, 9, 10];
+                    var arr: []int = [5, 9, 10];
                 end
             "});
     }
@@ -281,7 +281,7 @@ mod tests {
     fn declaring_variable_with_empty_array_literal_and_type_notation() {
         assert_is_ok(indoc! {"
                 fn main() do
-                    var arr: []Int = [];
+                    var arr: []int = [];
                 end
             "});
     }
@@ -290,7 +290,7 @@ mod tests {
     fn declaring_variable_with_nested_arrays_and_type_notation() {
         assert_is_ok(indoc! {"
                 fn main() do
-                    var arr: [][]Int = [[5, 9, 10], [1, 2, 3]];
+                    var arr: [][]int = [[5, 9, 10], [1, 2, 3]];
                 end
             "});
     }
@@ -299,7 +299,7 @@ mod tests {
     fn declaring_variable_with_nested_empty_arrays_and_type_notation() {
         assert_is_ok(indoc! {"
                 fn main() do
-                    var arr: [][][]Int = [[], []];
+                    var arr: [][][]int = [[], []];
                 end
             "});
     }
@@ -311,11 +311,11 @@ mod tests {
                     var arr = [five, six];
                 end
 
-                fn five(): Int do
+                fn five(): int do
                     return 5;
                 end
 
-                fn six(): Int do
+                fn six(): int do
                     return 6;
                 end
             "});

--- a/compiler/src/semantic/variable.rs
+++ b/compiler/src/semantic/variable.rs
@@ -1,14 +1,14 @@
 use super::{
     error::{Error, Result},
-    expression::ExpressionChecker,
+    expression::ExpressionAnalyzer,
     state::SharedState,
-    tn::TypeNotationChecker,
+    tn::TypeNotationAnalyzer,
     types::Type,
 };
 use crate::ast::AstNode;
 use logos::Span;
 
-/// Checker for variable declaration statement.
+/// Analyzer for variable declaration statement.
 ///
 /// ### ✅ Valid Examples
 ///
@@ -38,23 +38,23 @@ use logos::Span;
 /// ```text
 /// var x: Int = 5.0;
 /// ```
-pub struct VariableDeclarationChecker<'a> {
+pub struct VariableDeclarationAnalyzer<'a> {
     node: &'a AstNode,
     state: &'a SharedState,
 }
 
-impl<'a> VariableDeclarationChecker<'a> {
+impl<'a> VariableDeclarationAnalyzer<'a> {
     pub const fn new(node: &'a AstNode, state: &'a SharedState) -> Self {
         Self { node, state }
     }
 }
 
-impl VariableDeclarationChecker<'_> {
-    pub fn check(&self) -> Result<Type> {
-        let val_t = ExpressionChecker::new(self.val(), self.state).check()?;
+impl VariableDeclarationAnalyzer<'_> {
+    pub fn analyze(&self) -> Result<Type> {
+        let val_t = ExpressionAnalyzer::new(self.val(), self.state).analyze()?;
 
         let var_t = if let Some(tn) = self.tn() {
-            let t = self.check_tn(tn, &val_t)?;
+            let t = self.analyze_tn(tn, &val_t)?;
             Some(t)
         } else {
             if val_t.is_array_with_unknown_elem_t() {
@@ -70,8 +70,8 @@ impl VariableDeclarationChecker<'_> {
         Ok(Type::Void)
     }
 
-    fn check_tn(&self, tn: &AstNode, val_t: &Type) -> Result<Type> {
-        let t = TypeNotationChecker::new(tn, self.state).check()?;
+    fn analyze_tn(&self, tn: &AstNode, val_t: &Type) -> Result<Type> {
+        let t = TypeNotationAnalyzer::new(tn, self.state).analyze()?;
 
         // Check if the value type is compatible with the variable
         Type::assert_assignable(val_t, &t, || self.span().clone())?;

--- a/compiler/src/semantic/variable.rs
+++ b/compiler/src/semantic/variable.rs
@@ -54,18 +54,17 @@ impl VariableDeclarationAnalyzer<'_> {
         let val_t = ExpressionAnalyzer::new(self.val(), self.state).analyze()?;
 
         let var_t = if let Some(tn) = self.tn() {
-            let t = self.analyze_tn(tn, &val_t)?;
-            Some(t)
+            self.analyze_tn(tn, &val_t)?
         } else {
             if val_t.is_array_with_unknown_elem_t() {
                 return Err(Error::UnableToInferType {
                     span: self.id().span().clone(),
                 });
             }
-            None
+            val_t.morph_default()
         };
 
-        self.save_symbol(&self.id_string(), var_t.unwrap_or(val_t), self.span())?;
+        self.save_symbol(&self.id_string(), var_t, self.span())?;
 
         Ok(Type::Void)
     }

--- a/compiler/src/semantic/while_loop.rs
+++ b/compiler/src/semantic/while_loop.rs
@@ -1,6 +1,9 @@
 use super::{
-    body::BodyChecker, error::Result, expression::ExpressionChecker, scope::Scope,
-    state::SharedState, types::Type,
+    body::BodyChecker,
+    error::Result,
+    expression::ExpressionChecker,
+    state::{scope::Scope, SharedState},
+    types::Type,
 };
 use crate::ast::AstNode;
 

--- a/compiler/src/semantic/while_loop.rs
+++ b/compiler/src/semantic/while_loop.rs
@@ -1,13 +1,13 @@
 use super::{
-    body::BodyChecker,
+    body::BodyAnalyzer,
     error::Result,
-    expression::ExpressionChecker,
+    expression::ExpressionAnalyzer,
     state::{scope::ScopeVariant, SharedState},
     types::Type,
 };
 use crate::ast::AstNode;
 
-/// Checker for `while` loop statement.
+/// Analyzer for `while` loop statement.
 ///
 /// ### ✅ Valid Examples
 ///
@@ -39,28 +39,28 @@ use crate::ast::AstNode;
 ///     # Invalid
 /// end
 /// ```
-pub struct WhileLoopChecker<'a> {
+pub struct WhileLoopAnalyzer<'a> {
     node: &'a AstNode,
     state: &'a SharedState,
 }
 
-impl<'a> WhileLoopChecker<'a> {
+impl<'a> WhileLoopAnalyzer<'a> {
     pub const fn new(node: &'a AstNode, state: &'a SharedState) -> Self {
         Self { node, state }
     }
 }
 
-impl WhileLoopChecker<'_> {
-    pub fn check(&self) -> Result<Type> {
+impl WhileLoopAnalyzer<'_> {
+    pub fn analyze(&self) -> Result<Type> {
         // Expecting boolean type for the condition
 
-        let cond_t = ExpressionChecker::new(self.cond(), self.state).check()?;
+        let cond_t = ExpressionAnalyzer::new(self.cond(), self.state).analyze()?;
         Type::assert_boolean(&cond_t, || self.cond().span().clone())?;
 
         // Check all statements inside the body with a new scope
 
         self.state.with_scope(ScopeVariant::Loop, || {
-            BodyChecker::new(self.node, self.state).check()
+            BodyAnalyzer::new(self.node, self.state).analyze()
         })?;
 
         Ok(Type::Void)

--- a/compiler/src/semantic/while_loop.rs
+++ b/compiler/src/semantic/while_loop.rs
@@ -63,7 +63,7 @@ impl WhileLoopChecker<'_> {
             BodyChecker::new(self.ss, self.node).check()
         })?;
 
-        Ok(Type::new("Void"))
+        Ok(Type::Void)
     }
 
     fn cond(&self) -> &AstNode {

--- a/compiler/src/semantic/while_loop.rs
+++ b/compiler/src/semantic/while_loop.rs
@@ -2,7 +2,7 @@ use super::{
     body::BodyChecker,
     error::Result,
     expression::ExpressionChecker,
-    state::{scope::Scope, SharedState},
+    state::{scope::ScopeVariant, SharedState},
     types::Type,
 };
 use crate::ast::AstNode;
@@ -59,7 +59,7 @@ impl WhileLoopChecker<'_> {
 
         // Check all statements inside the body with a new scope
 
-        self.state.ss.with_scope(Scope::new_loop_scope(), || {
+        self.state.with_scope(ScopeVariant::Loop, || {
             BodyChecker::new(self.node, self.state).check()
         })?;
 

--- a/compiler/src/semantic/while_loop.rs
+++ b/compiler/src/semantic/while_loop.rs
@@ -63,7 +63,7 @@ impl WhileLoopAnalyzer<'_> {
             BodyAnalyzer::new(self.node, self.state).analyze()
         })?;
 
-        Ok(Type::Void)
+        Ok(Type::void())
     }
 
     fn cond(&self) -> &AstNode {

--- a/docs/examples/fibonacci.kaba
+++ b/docs/examples/fibonacci.kaba
@@ -4,7 +4,7 @@ fn main() do
     debug fibonacci(6);
 end
 
-fn fibonacci(n: Int): Int do
+fn fibonacci(n: int): int do
     if n <= 0 do
         return 0;
     else if n == 1 || n == 2 do

--- a/docs/features.md
+++ b/docs/features.md
@@ -9,7 +9,7 @@ Kaba is a:
 1. Statically typed language, where every type violations will be caught before the program is actually run.
 
     ```text
-    var x: Int = 5;
+    var x: int = 5;
 
     x = false;  # ERROR
     ```
@@ -57,12 +57,12 @@ fn foo() do
 end
 ```
 
-From the example above, `foo()` return type is `Void` (not returning anything).
+From the example above, `foo()` return type is `void` (not returning anything).
 
 To return a value from functions, use the `return` keyword (and don't forget to specify the type notation as well):
 
 ```text
-fn yield_five(): Int do
+fn yield_five(): int do
     return 5;
 end
 ```
@@ -96,7 +96,7 @@ If you want to specify the type manually, use the following syntax:
 
 ```text
 fn main() do
-    var x: Int = 5;
+    var x: int = 5;
 end
 ```
 
@@ -104,7 +104,7 @@ If value type is incompatible with the variable, the compiler will throw an erro
 
 ```text
 fn main() do
-    var x: Int = 10.0;  # ERROR
+    var x: int = 10.0;  # ERROR
 end
 ```
 
@@ -150,7 +150,7 @@ fn main() do
 end
 ```
 
-Note that the compiler will reject if the expression evaluates to `Void` type:
+Note that the compiler will reject if the expression evaluates to `void` type:
 
 ```text
 fn main() do
@@ -163,11 +163,11 @@ end
 
 ## Data types
 
-Currently, Kaba only support these (non-`Void`) data types:
+Currently, Kaba only support these (non-`void`) data types:
 
-1. Integer (`Int`)
-2. Float (`Float`)
-3. Boolean (`Bool`)
+1. Integer (`int`)
+2. Float (`float`)
+3. Boolean (`bool`)
 4. Callable
 5. Array
 
@@ -175,15 +175,15 @@ Currently, Kaba only support these (non-`Void`) data types:
 
 ```text
 fn main() do
-    var a: Int = 10;
+    var a: int = 10;
 
-    var b: Float = 5.0;
+    var b: float = 5.0;
 
-    var c: Bool = false;
+    var c: bool = false;
 
-    var d: () -> Void = foo;
+    var d: () -> void = foo;
 
-    var e: []Int = [99, 101];
+    var e: []int = [99, 101];
 end
 
 fn foo() do
@@ -202,7 +202,7 @@ Kaba can infer the type of an array:
 fn main do
     var arr = [false, true, true];
 
-    # The type of `arr` is `[]Bool`
+    # The type of `arr` is `[]bool`
 
     debug arr[1];   // `true`
 end
@@ -219,7 +219,7 @@ fn main() do
     foo(arr);
 end
 
-fn foo(arr: [][]Int) do
+fn foo(arr: [][]int) do
     debug arr[1][1];
 end
 ```
@@ -229,7 +229,7 @@ On a side note, statements such as variable declaration and `each` loop are unab
 ```text
 fn main() do
     # Use this...
-    var x: []Int = [];
+    var x: []int = [];
 
     # Not this...
     var x = [];

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -251,11 +251,11 @@ mod tests {
                     debug add_two(5);
                 end
 
-                fn add_two(n: Int): Int do
+                fn add_two(n: int): int do
                     return n + get_two();
                 end
 
-                fn get_two(): Int do
+                fn get_two(): int do
                     return 2;
                 end
             "},
@@ -272,7 +272,7 @@ mod tests {
                     dbg(x);
                 end
 
-                fn dbg(n: Int) do
+                fn dbg(n: int) do
                     debug n;
                 end
             "},
@@ -288,11 +288,11 @@ mod tests {
                     debug one() + two();
                 end
 
-                fn one(): Int do
+                fn one(): int do
                     return 1;
                 end
 
-                fn two(): Int do
+                fn two(): int do
                     return 2;
                 end
             "},
@@ -308,7 +308,7 @@ mod tests {
                     debug fibonacci(3);
                 end
 
-                fn fibonacci(n: Int): Int do
+                fn fibonacci(n: int): int do
                     if n == 1 || n == 2 do
                         return 1;
                     end
@@ -327,7 +327,7 @@ mod tests {
                     count_to_zero(5);
                 end
 
-                fn count_to_zero(n: Int) do
+                fn count_to_zero(n: int) do
                     if n < 0 do
                         return;
                     end
@@ -347,15 +347,15 @@ mod tests {
                     print(produce);
                 end
 
-                fn print(producer: () -> Int) do
-                    var x: () -> Int = producer;
+                fn print(producer: () -> int) do
+                    var x: () -> int = producer;
                     debug x();
 
                     var y = producer;
                     debug y();
                 end
 
-                fn produce(): Int do
+                fn produce(): int do
                     return 5;
                 end
             "},
@@ -371,11 +371,11 @@ mod tests {
                     debug foo()();
                 end
 
-                fn foo(): () -> Int do
+                fn foo(): () -> int do
                     return bar;
                 end
 
-                fn bar(): Int do
+                fn bar(): int do
                     return 25;
                 end
             "},
@@ -441,15 +441,15 @@ mod tests {
                     end
                 end
 
-                fn add_one(n: Int): Int do
+                fn add_one(n: int): int do
                     return n + 1;
                 end
 
-                fn add_two(n: Int): Int do
+                fn add_two(n: int): int do
                     return n + 2;
                 end
 
-                fn add_three(n: Int): Int do
+                fn add_three(n: int): int do
                     return n + 3;
                 end
             "},
@@ -474,7 +474,7 @@ mod tests {
                     debug arr_2[0];
                 end
 
-                fn foo(): []Int do
+                fn foo(): []int do
                     return [0];
                 end
             "},

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -30,7 +30,7 @@ impl<'a> Runtime<'a> {
     }
 
     pub fn run(&'a self) -> Result<()> {
-        let body = if let AstNode::Program { body } = &self.ast.as_ref().unwrap() {
+        let body = if let AstNode::Program { body, .. } = &self.ast.as_ref().unwrap() {
             body
         } else {
             unreachable!()

--- a/src/runtime/body.rs
+++ b/src/runtime/body.rs
@@ -28,7 +28,7 @@ impl<'a> BodyRunner<'a> {
 
     fn body(&self) -> &'a [AstNode] {
         match self.ast {
-            AstNode::Program { body }
+            AstNode::Program { body, .. }
             | AstNode::If { body, .. }
             | AstNode::Else { body, .. }
             | AstNode::While { body, .. }

--- a/src/runtime/expression.rs
+++ b/src/runtime/expression.rs
@@ -59,9 +59,10 @@ impl<'a> ExpressionRunner<'a> {
     fn literal_to_value(&self, lit: &'a Literal) -> Result<RuntimeValue> {
         let val = match lit {
             Literal::Void => RuntimeValue::Void,
-            Literal::Integer(n) => RuntimeValue::Integer((*n).try_into().unwrap()),
+            Literal::Bool(b) => RuntimeValue::Boolean(*b),
+
+            Literal::Int(n) => RuntimeValue::Integer((*n).try_into().unwrap()),
             Literal::Float(n) => RuntimeValue::Float(*n),
-            Literal::Boolean(b) => RuntimeValue::Boolean(*b),
 
             Literal::Array(arr) => {
                 let mut elems = vec![];

--- a/src/runtime/expression.rs
+++ b/src/runtime/expression.rs
@@ -340,7 +340,7 @@ impl ExpressionRunner<'_> {
         args: &[RuntimeValue],
     ) -> Result<RuntimeValue> {
         if let RuntimeValue::Function(ptr) = f_ptr {
-            let top_level_body = if let AstNode::Program { body } = &self.root {
+            let top_level_body = if let AstNode::Program { body, .. } = &self.root {
                 body
             } else {
                 unreachable!()


### PR DESCRIPTION
- Rename built-in types to lowercase version, such as from `Int` to `int`
- Replace the scope stack with symbol tree (an implementation of symbol table)