### PR TITLE
change block delimiters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - (Internal) replace semantic analyzer's scope stack with symbol tree (by [@snaztoz](https://github.com/snaztoz) in [#43](https://github.com/snaztoz/kaba/pull/43))
 - Change array literal syntax.
 - Change single-line comment token from `#` to `//`.
+- Change block delimiters from `do ... end` to `{ ... }`.
 
 ## [0.4.0] - 2024-12-06
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Next, create a [Kaba program file](docs/features.md) (the extension **must be** 
 For this example, let's create a file called `hello.kaba` with the following code:
 
 ```text
-fn main() do
+fn main() {
     debug "Hello, World!";
-end
+}
 ```
 
 Then run the following shell command:

--- a/compiler/src/lexer.rs
+++ b/compiler/src/lexer.rs
@@ -91,8 +91,6 @@ pub enum TokenKind {
     #[token("in")]       In,
     #[token("fn")]       Fn,
     #[token("return")]   Return,
-    #[token("do")]       Do,
-    #[token("end")]      End,
     #[token("as")]       As,
     #[token("debug")]    Debug,
 
@@ -172,8 +170,6 @@ impl Display for TokenKind {
             Self::In => write!(f, "`in` keyword"),
             Self::Fn => write!(f, "`fn` keyword"),
             Self::Return => write!(f, "`return` keyword"),
-            Self::Do => write!(f, "`do` keyword"),
-            Self::End => write!(f, "`end` keyword"),
             Self::As => write!(f, "`as` keyword"),
             Self::Debug => write!(f, "`debug` keyword"),
 

--- a/compiler/src/parser/block.rs
+++ b/compiler/src/parser/block.rs
@@ -47,7 +47,7 @@ impl BlockParser<'_> {
 
             if self.tokens.current_is(&TokenKind::Eof) {
                 return Err(ParsingError::UnexpectedToken {
-                    expect: TokenKind::End,
+                    expect: TokenKind::RBrace,
                     found: TokenKind::Eof,
                     span: self.tokens.current().span,
                 });

--- a/compiler/src/parser/each_loop.rs
+++ b/compiler/src/parser/each_loop.rs
@@ -70,7 +70,7 @@ mod tests {
     #[test]
     fn each_statement() {
         parse_and_assert_result(
-            "each elem in arr do end",
+            "each elem in arr {}",
             AstNode::Each {
                 elem_id: Box::new(AstNode::Identifier {
                     name: String::from("elem"),
@@ -81,7 +81,7 @@ mod tests {
                     span: 13..16,
                 }),
                 body: vec![],
-                span: 0..23,
+                span: 0..19,
             },
         );
     }

--- a/compiler/src/parser/function.rs
+++ b/compiler/src/parser/function.rs
@@ -127,7 +127,7 @@ mod tests {
     #[test]
     fn empty_function_definition() {
         parse_and_assert_result(
-            "fn foo() do end",
+            "fn foo() {}",
             AstNode::FunctionDefinition {
                 id: Box::new(AstNode::Identifier {
                     name: String::from("foo"),
@@ -136,7 +136,7 @@ mod tests {
                 params: vec![],
                 return_tn: None,
                 body: vec![],
-                span: 0..15,
+                span: 0..11,
             },
         );
     }
@@ -144,7 +144,7 @@ mod tests {
     #[test]
     fn function_definition_with_parameters_and_trailing_comma() {
         parse_and_assert_result(
-            "fn foo(x: int, y: bool,) do end",
+            "fn foo(x: int, y: bool,) {}",
             AstNode::FunctionDefinition {
                 id: Box::new(AstNode::Identifier {
                     name: String::from("foo"),
@@ -174,7 +174,7 @@ mod tests {
                 ],
                 return_tn: None,
                 body: vec![],
-                span: 0..31,
+                span: 0..27,
             },
         );
     }
@@ -182,7 +182,7 @@ mod tests {
     #[test]
     fn function_definition_with_parameter_and_body() {
         parse_and_assert_result(
-            "fn write(x: int) do print(x); end",
+            "fn write(x: int) { print(x); }",
             AstNode::FunctionDefinition {
                 id: Box::new(AstNode::Identifier {
                     name: String::from("write"),
@@ -202,15 +202,15 @@ mod tests {
                 body: vec![AstNode::FunctionCall {
                     callee: Box::new(AstNode::Identifier {
                         name: String::from("print"),
-                        span: 20..25,
+                        span: 19..24,
                     }),
                     args: vec![AstNode::Identifier {
                         name: String::from("x"),
-                        span: 26..27,
+                        span: 25..26,
                     }],
-                    span: 20..28,
+                    span: 19..27,
                 }],
-                span: 0..33,
+                span: 0..30,
             },
         );
     }
@@ -218,7 +218,7 @@ mod tests {
     #[test]
     fn function_definition_with_return_statement() {
         parse_and_assert_result(
-            "fn foo(): int do return 5; end",
+            "fn foo(): int { return 5; }",
             AstNode::FunctionDefinition {
                 id: Box::new(AstNode::Identifier {
                     name: String::from("foo"),
@@ -232,11 +232,11 @@ mod tests {
                 body: vec![AstNode::Return {
                     expr: Some(Box::new(AstNode::Literal {
                         lit: Literal::Int(5),
-                        span: 24..25,
+                        span: 23..24,
                     })),
-                    span: 17..25,
+                    span: 16..24,
                 }],
-                span: 0..30,
+                span: 0..27,
             },
         );
     }

--- a/compiler/src/parser/while_loop.rs
+++ b/compiler/src/parser/while_loop.rs
@@ -44,14 +44,14 @@ mod tests {
     #[test]
     fn while_statement() {
         parse_and_assert_result(
-            "while true do end",
+            "while true {}",
             AstNode::While {
                 cond: Box::new(AstNode::Literal {
                     lit: Literal::Bool(true),
                     span: 6..10,
                 }),
                 body: vec![],
-                span: 0..17,
+                span: 0..13,
             },
         );
     }
@@ -59,17 +59,17 @@ mod tests {
     #[test]
     fn while_statement_with_loop_control_statements() {
         parse_and_assert_result(
-            "while true do continue; break; end",
+            "while true { continue; break; }",
             AstNode::While {
                 cond: Box::new(AstNode::Literal {
                     lit: Literal::Bool(true),
                     span: 6..10,
                 }),
                 body: vec![
-                    AstNode::Continue { span: 14..22 },
-                    AstNode::Break { span: 24..29 },
+                    AstNode::Continue { span: 13..21 },
+                    AstNode::Break { span: 23..28 },
                 ],
-                span: 0..34,
+                span: 0..31,
             },
         );
     }

--- a/compiler/src/semantic/assignment.rs
+++ b/compiler/src/semantic/assignment.rs
@@ -135,7 +135,7 @@ mod tests {
     #[test]
     fn assigning_variables() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     var x = 0;
                     x = 10;
 
@@ -144,87 +144,87 @@ mod tests {
 
                     var z = false;
                     z = true;
-                end
+                }
             "})
     }
 
     #[test]
     fn assigning_variable_using_shorthand_forms() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     var i = 0;
                     i += 1;
                     i -= 2;
                     i *= 3;
                     i /= 4;
                     i %= 5;
-                end
+                }
             "})
     }
 
     #[test]
     fn mod_assign_with_float_value() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     var i = 5.0;
                     i %= 2.5;
-                end
+                }
             "})
     }
 
     #[test]
     fn assigning_value_with_non_existing_variable() {
         assert_is_err(indoc! {"
-                fn main() do
+                fn main() {
                     var x: float = 5.0;
                     x = y;
-                end
+                }
             "})
     }
 
     #[test]
     fn assigning_overflowed_value() {
         assert_is_err(indoc! {"
-                fn main() do
+                fn main() {
                     var x: sbyte = 0;
                     x = 128;
-                end
+                }
             "})
     }
 
     #[test]
     fn using_math_expression_as_lhs_in_assignment() {
         assert_is_err(indoc! {"
-                fn main() do
+                fn main() {
                     1 + 1 = 5;
-                end
+                }
             "})
     }
 
     #[test]
     fn using_boolean_expression_as_lhs_in_assignment() {
         assert_is_err(indoc! {"
-                fn main() do
+                fn main() {
                     true || false = false;
-                end
+                }
             "})
     }
 
     #[test]
     fn using_integer_grouped_expression_as_lhs_in_assignment() {
         assert_is_err(indoc! {"
-                fn main() do
+                fn main() {
                     (50) = true;
-                end
+                }
             "})
     }
 
     #[test]
     fn using_boolean_type_in_shorthand_assignment() {
         assert_is_err(indoc! {"
-                fn main() do
+                fn main() {
                     true += true;
-                end
+                }
             "})
     }
 
@@ -235,22 +235,22 @@ mod tests {
     #[test]
     fn assign_to_array_element() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     var arr = []bool{ true, false, true };
 
                     arr[1] = true;
-                end
+                }
             "});
     }
 
     #[test]
     fn shorthand_assign_to_array_element() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     var arr = []float{ 0.5, 1.1, 2.3 };
 
                     arr[0] += 5.5;
-                end
+                }
             "});
     }
 }

--- a/compiler/src/semantic/conditional.rs
+++ b/compiler/src/semantic/conditional.rs
@@ -153,73 +153,73 @@ mod tests {
     #[test]
     fn if_else_statements() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     var condition1 = 5 < 10;
                     var condition2 = 0.5 < 0.75;
 
-                    if condition1 do
+                    if condition1 {
                         debug condition1;
                         debug 1;
-                    else if condition2 do
+                    } else if condition2 {
                         debug condition2;
                         debug 2;
-                    else do
+                    } else {
                         debug 0;
-                    end
-                end
+                    }
+                }
             "})
     }
 
     #[test]
     fn nested_if_statements() {
         assert_is_ok(indoc! {"
-                fn main() do
-                    if 1 + 1 == 2 do
-                        if 2 + 2 == 4 do
-                            if 3 + 3 == 6 do
+                fn main() {
+                    if 1 + 1 == 2 {
+                        if 2 + 2 == 4 {
+                            if 3 + 3 == 6 {
                                 debug true;
-                            end
-                        end
-                    end
-                end
+                            }
+                        }
+                    }
+                }
             "})
     }
 
     #[test]
     fn using_variable_declared_inside_conditional_scope_from_outside() {
         assert_is_err(indoc! {"
-                fn main() do
-                    if true do
+                fn main() {
+                    if true {
                         var x = 50;
                         debug x;
-                    end
+                    }
 
                     debug x;
-                end
+                }
             "})
     }
 
     #[test]
     fn using_math_expression_as_condition_in_if_statement() {
         assert_is_err(indoc! {"
-                fn main() do
-                    if 1 + 1 do
+                fn main() {
+                    if 1 + 1 {
                         debug 1;
-                    end
-                end
+                    }
+                }
             "})
     }
 
     #[test]
     fn using_variable_declared_in_sibling_branch_scope() {
         assert_is_err(indoc! {"
-                fn main() do
-                    if true do
+                fn main() {
+                    if true {
                         var x = 50;
-                    else do
+                    } else {
                         debug x;
-                    end
-                end
+                    }
+                }
             "})
     }
 }

--- a/compiler/src/semantic/conditional.rs
+++ b/compiler/src/semantic/conditional.rs
@@ -14,33 +14,33 @@ use crate::ast::AstNode;
 /// * The provided condition must be an expression that returns a boolean:
 ///
 /// ```text
-/// if true do
+/// if true {
 ///     // ...
-/// end
+/// }
 /// ```
 ///
 /// * This statement can have multiple branches:
 ///
 /// ```text
-/// if false do
+/// if false {
 ///     // Won't be executed
-/// else if !true do
+/// } else if !true {
 ///     // Won't be executed
-/// else do
+/// } else {
 ///     // Will be executed
-/// end
+/// }
 /// ```
 ///
 /// * It can be the last statement of a function:
 ///
 /// ```text
-/// fn foo(): int do
-///     if false do
+/// fn foo(): int {
+///     if false {
 ///         return 5;
-///     else do
+///     } else {
 ///         return 99;
-///     end
-/// end
+///     }
+/// }
 /// ```
 ///
 /// ### ❌ Invalid Examples
@@ -49,9 +49,9 @@ use crate::ast::AstNode;
 ///   boolean:
 ///
 /// ```text
-/// if 1 + 1 do
+/// if 1 + 1 {
 ///     // Invalid
-/// end
+/// }
 /// ```
 ///
 /// * For a series of conditional statement branches to be able to be placed as
@@ -59,13 +59,13 @@ use crate::ast::AstNode;
 ///   (exhaustive). Else, the compiler will throw an error.
 ///
 /// ```text
-/// fn foo(): int do
-///     if !true do
+/// fn foo(): int {
+///     if !true {
 ///         return 1;
-///     else do
+///     } else {
 ///         // Error: This branch should returns something!
-///     end
-/// end
+///     }
+/// }
 /// ```
 pub struct ConditionalBranchAnalyzer<'a> {
     node: &'a AstNode,

--- a/compiler/src/semantic/each_loop.rs
+++ b/compiler/src/semantic/each_loop.rs
@@ -96,39 +96,38 @@ mod tests {
     #[test]
     fn each_loop_statements() {
         assert_is_ok(indoc! {"
-                fn main() do
-                    each n in []int{1, 2, 3} do
+                fn main() {
+                    each n in []int{1, 2, 3} {
                         debug n;
-                    end
+                    }
 
                     var arr = []int{4, 5, 6};
-                    each n in arr do
+                    each n in arr {
                         debug n;
-                    end
-                end
+                    }
+                }
             "});
     }
 
     #[test]
     fn each_loop_statement_with_non_array_expression() {
         assert_is_err(indoc! {"
-                fn main() do
-                    each n in true do
+                fn main() {
+                    each n in true {
                         debug n;
-                    end
-                end
+                    }
+                }
             "});
     }
 
     #[test]
     fn accessing_elem_id_outside_scope() {
         assert_is_err(indoc! {"
-                fn main() do
-                    each n in []int{1, 2} do
-                    end
+                fn main() {
+                    each n in []int{1, 2} {}
 
                     debug n;
-                end
+                }
             "});
     }
 }

--- a/compiler/src/semantic/each_loop.rs
+++ b/compiler/src/semantic/each_loop.rs
@@ -14,19 +14,19 @@ use crate::ast::AstNode;
 /// * The provided expression must evaluates to an array:
 ///
 /// ```text
-/// each n in []int{ 0, 1, 2 } do
+/// each n in []int{ 0, 1, 2 } {
 ///     // ...
-/// end
+/// }
 /// ```
 ///
 /// * With `break` or `continue` statement:
 ///
 /// ```text
-/// each n in []int{ 0, 1, 2 } do
-///     if !false do
+/// each n in []int{ 0, 1, 2 } {
+///     if !false {
 ///         break;
-///     end
-/// end
+///     }
+/// }
 /// ```
 ///
 /// ### ❌ Invalid Examples
@@ -34,9 +34,9 @@ use crate::ast::AstNode;
 /// * The provided expression can't evaluates to types other than array:
 ///
 /// ```text
-/// each n in true do
+/// each n in true {
 ///     // Invalid
-/// end
+/// }
 /// ```
 pub struct EachLoopAnalyzer<'a> {
     node: &'a AstNode,

--- a/compiler/src/semantic/function.rs
+++ b/compiler/src/semantic/function.rs
@@ -210,333 +210,333 @@ mod tests {
     #[test]
     fn defining_function_without_parameter_or_return_type() {
         assert_is_ok(indoc! {"
-                fn add() do end
+                fn add() {}
             "});
     }
 
     #[test]
     fn defining_duplicated_functions() {
         assert_is_err(indoc! {"
-                fn print_sum_of(a: int, b: int,) do
+                fn print_sum_of(a: int, b: int) {
                     debug a + b;
-                end
+                }
 
-                fn print_sum_of(a: float, b: float) do
+                fn print_sum_of(a: float, b: float) {
                     debug a + b;
-                end
+                }
             "});
     }
 
     #[test]
     fn defining_functions_both_with_parameters_and_return_type() {
         assert_is_ok(indoc! {"
-                fn sum(x: int, y: int): int do
+                fn sum(x: int, y: int): int {
                     return x + y;
-                end
+                }
             "});
     }
 
     #[test]
     fn recursive_fibonacci_function() {
         assert_is_ok(indoc! {"
-                fn fibonacci(n: int): int do
-                    if n == 0 do
+                fn fibonacci(n: int): int {
+                    if n == 0 {
                         return 0;
-                    else if n == 1 || n == 2 do
+                    } else if n == 1 || n == 2 {
                         return 1;
-                    end
+                    }
                     return fibonacci(n-1) + fibonacci(n-2);
-                end
+                }
             "});
     }
 
     #[test]
     fn recursive_functions_with_void_return_type() {
         assert_is_ok(indoc! {"
-                fn count_to_zero(n: int) do
+                fn count_to_zero(n: int) {
                     debug n;
-                    if n == 0 do
+                    if n == 0 {
                         return;
-                    end
+                    }
                     count_to_zero(n-1);
-                end
+                }
 
-                fn main() do
+                fn main() {
                     count_to_zero(10);
-                end
+                }
             "});
     }
 
     #[test]
     fn returning_from_functions_with_conditional_and_loop_statements() {
         assert_is_ok(indoc! {"
-                fn first(): int do
+                fn first(): int {
                     return 5;
-                end
+                }
 
-                fn second(): int do
-                    if false do
+                fn second(): int {
+                    if false {
                         return 0;
-                    else do
+                    } else {
                         return 1;
-                    end
-                end
+                    }
+                }
 
-                fn third(): int do
-                    if false do
+                fn third(): int {
+                    if false {
                         return 0;
-                    end
+                    }
                     return 1;
-                end
+                }
 
-                fn fourth(): int do
-                    while false do
+                fn fourth(): int {
+                    while false {
                         return 0;
-                    end
+                    }
                     return 1;
-                end
+                }
 
-                fn fifth(): int do
+                fn fifth(): int {
                     return 1;
 
-                    if false do
+                    if false {
                         return 0;
-                    end
-                end
+                    }
+                }
             "});
     }
 
     #[test]
     fn defining_functions_not_in_order() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     call_foo();
-                end
+                }
 
-                fn call_foo() do
+                fn call_foo() {
                     call_bar();
-                end
+                }
 
-                fn call_bar() do
+                fn call_bar() {
                     debug true;
-                end
+                }
             "})
     }
 
     #[test]
-    fn prevent_incompatible_int_type_on_function_return_value() {
+    fn prevent_indocompatible_int_type_on_function_return_value() {
         assert_is_err(indoc! {"
-                fn main() do
+                fn main() {
                     var x: int = foo();
-                end
+                }
 
-                fn foo(): sbyte do
+                fn foo(): sbyte {
                     return 5;
-                end
+                }
             "});
     }
 
     #[test]
     fn aliasing_function_identifier() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     var aliased = return_two;
 
                     debug aliased();
-                end
+                }
 
-                fn return_two(): int do
+                fn return_two(): int {
                     return 2;
-                end
+                }
             "});
     }
 
     #[test]
     fn using_function_type_as_function_parameter() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     debug get_num(produce);
-                end
+                }
 
-                fn get_num(producer: () -> int): int do
+                fn get_num(producer: () -> int): int {
                     return producer() + 5;
-                end
+                }
 
-                fn produce(): int do
+                fn produce(): int {
                     return 10;
-                end
+                }
             "});
     }
 
     #[test]
     fn calling_function_returned_by_another_function_call() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     debug foo()();
-                end
+                }
 
-                fn foo(): () -> int do
+                fn foo(): () -> int {
                     return bar;
-                end
+                }
 
-                fn bar(): int do
+                fn bar(): int {
                     return 25;
-                end
+                }
             "});
     }
 
     #[test]
     fn calling_function_with_array_parameter() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     foo([]int{1, 2, 3});
-                end
+                }
 
-                fn foo(arr: []int) do
-                end
+                fn foo(arr: []int) {
+                }
             "});
     }
 
     #[test]
     fn calling_function_with_array_parameter_using_different_array_sizes() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     foo([]int{1, 2, 3});
 
                     foo([]int{});
 
                     foo([]int{1,});
-                end
+                }
 
-                fn foo(arr: []int) do
-                end
+                fn foo(arr: []int) {
+                }
             "});
     }
 
     #[test]
     fn returning_array_from_a_function() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     var arr_1: []int = foo();
                     var arr_2: []int = foo();
 
                     arr_1[0] = 10;
-                end
+                }
 
-                fn foo(): []int do
+                fn foo(): []int {
                     return []int{1, 2, 3};
-                end
+                }
             "});
     }
 
     #[test]
     fn defining_function_not_in_global_scope() {
         assert_is_err(indoc! {"
-                fn main() do
-                    if true do
-                        fn foo() do end
-                    end
-                end
+                fn main() {
+                    if true {
+                        fn foo() {}
+                    }
+                }
             "});
     }
 
     #[test]
     fn defining_function_with_a_non_existing_return_type() {
         assert_is_err(indoc! {"
-                fn foo(): NonExistingType do end
+                fn foo(): NonExistingType { }
             "});
     }
 
     #[test]
     fn defining_function_with_duplicated_parameter_name() {
         assert_is_err(indoc! {"
-                fn add_sum_of(x: int, x: int) do end
+                fn add_sum_of(x: int, x: int) { }
             "});
     }
 
     #[test]
     fn defining_function_with_a_non_existing_parameter_type() {
         assert_is_err(indoc! {"
-                fn foo(x: NonExistingType) do end
+                fn foo(x: NonExistingType) { }
             "});
     }
 
     #[test]
     fn defining_function_with_void_parameter_type() {
         assert_is_err(indoc! {"
-                fn foo(x: Void) do end
+                fn foo(x: Void) { }
             "});
     }
 
     #[test]
     fn returning_value_from_function_with_void_return_type() {
         assert_is_err(indoc! {"
-                fn foo() do
+                fn foo() {
                     return 5;
-                end
+                }
             "});
     }
 
     #[test]
     fn returning_value_from_function_with_mismatched_return_type() {
         assert_is_err(indoc! {"
-                fn sum(x: int, y: int): int do
+                fn sum(x: int, y: int): int {
                     return 5.0;
-                end
+                }
             "});
     }
 
     #[test]
     fn invalid_statement_after_return() {
         assert_is_err(indoc! {"
-                fn get_five(): int do
+                fn get_five(): int {
                     return 5;
                     1 + true; // should be error
-                end
+                }
             "});
     }
 
     #[test]
     fn returning_non_existing_variable() {
         assert_is_err(indoc! {"
-                fn foo(): int do
+                fn foo(): int {
                     return not_exist;
-                end
+                }
             "});
     }
 
     #[test]
     fn defining_function_with_missing_return_in_other_branches() {
         assert_is_err(indoc! {"
-                fn foo(): int do
-                    if false do
+                fn foo(): int {
+                    if false {
                         return 5;
-                    end
-                end
+                    }
+                }
             "});
     }
 
     #[test]
     fn defining_function_with_missing_return_in_else_branch_or_outer_scope() {
         assert_is_err(indoc! {"
-                fn foo(): int do
-                    if false do
+                fn foo(): int {
+                    if false {
                         return 0;
-                    else if !true do
+                    } else if !true {
                         return 0;
-                    end
-                end
+                    }
+                }
             "});
     }
 
     #[test]
     fn defining_function_with_missing_return_in_outer_scope_of_while_statement() {
         assert_is_err(indoc! {"
-                fn foo(): int do
-                    while false do
+                fn foo(): int {
+                    while false {
                         return 0;
-                    end
-                end
+                    }
+                }
             "});
     }
 }

--- a/compiler/src/semantic/statement.rs
+++ b/compiler/src/semantic/statement.rs
@@ -112,21 +112,21 @@ mod tests {
     #[test]
     fn debug_expression() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     debug 17 * 5;
-                end
+                }
             "});
     }
 
     #[test]
     fn debug_expression_with_void_type() {
         assert_is_err(indoc! {"
-                fn main() do
+                fn main() {
                     debug this_is_void();
-                end
+                }
 
-                fn this_is_void() do
-                end
+                fn this_is_void() {
+                }
             "});
     }
 }

--- a/compiler/src/semantic/variable.rs
+++ b/compiler/src/semantic/variable.rs
@@ -119,122 +119,122 @@ mod tests {
     #[test]
     fn declaring_variable_with_type_annotation_and_initial_value() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     var x: int = 5;
-                end
+                }
             "});
     }
 
     #[test]
     fn declaring_variable_with_type_inferring() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     var x = 5;
-                end
+                }
             "});
     }
 
     #[test]
     fn declaring_variable_with_float_literal() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     var x: float = -0.5;
                     var y: double = 9.99;
-                end
+                }
             "});
     }
 
     #[test]
     fn declaring_variable_with_different_int_types() {
         assert_is_err(indoc! {"
-                fn main() do
+                fn main() {
                     var a: sbyte = 10;
                     var b: int = a;
-                end
+                }
             "});
     }
 
     #[test]
     fn declaring_sbyte_variable_with_overflow_constant() {
         assert_is_err(indoc! {"
-                fn main() do
+                fn main() {
                     var a: sbyte = 127 + 1;
-                end
+                }
             "});
     }
 
     #[test]
     fn declaring_short_variable_with_overflow_constant() {
         assert_is_err(indoc! {"
-                fn main() do
+                fn main() {
                     var a: short = -32768 - 1;
-                end
+                }
             "});
     }
 
     #[test]
     fn declaring_variable_with_bool_literal() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     var x = true;
-                end
+                }
             "});
     }
 
     #[test]
     fn declaring_variable_with_char_literal() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     var x = 'a';
                     var y: char = 'b';
-                end
+                }
             "});
     }
 
     #[test]
     fn declaring_variable_with_string_literal() {
         assert_is_ok(indoc! {r#"
-                fn main() do
+                fn main() {
                     var x = "abc def \n 123\t";
                     var y: string = "hello, world!";
-                end
+                }
             "#});
     }
 
     #[test]
     fn declaring_variable_with_void_type() {
         assert_is_err(indoc! {"
-                fn main() do
+                fn main() {
                     var x: Void = 5;
-                end
+                }
             "});
     }
 
     #[test]
     fn declaring_variable_with_incompatible_type() {
         assert_is_err(indoc! {"
-                fn main() do
+                fn main() {
                     var x: int = 5.0;
-                end
+                }
             "})
     }
 
     #[test]
     fn declaring_variable_with_non_existing_type() {
         assert_is_err(indoc! {"
-                fn main() do
+                fn main() {
                     var x: NonExistingType = 10;
-                end
+                }
             "})
     }
 
     #[test]
     fn redeclaring_variable_in_the_same_scope() {
         assert_is_err(indoc! {"
-                fn main() do
+                fn main() {
                     var x = 5;
                     var x = 10;
-                end
+                }
             "})
     }
 
@@ -245,37 +245,33 @@ mod tests {
     #[test]
     fn declaring_variable_with_function_pointer_as_value() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     var x: () -> int = produce;
 
                     debug x();
-                end
+                }
 
-                fn produce(): int do
+                fn produce(): int {
                     return 5;
-                end
+                }
             "});
     }
 
     #[test]
     fn declaring_callable_type_variable_with_non_existing_param_type() {
         assert_is_err(indoc! {"
-                fn main() do
-                end
+                fn main() {}
 
-                fn produce(f: (NotExist) -> Void) do
-                end
+                fn produce(f: (NotExist) -> Void) {}
             "});
     }
 
     #[test]
     fn declaring_callable_type_variable_with_non_existing_return_type() {
         assert_is_err(indoc! {"
-                fn main() do
-                end
+                fn main() {}
 
-                fn produce(f: () -> NotExist) do
-                end
+                fn produce(f: () -> NotExist) {}
             "});
     }
 
@@ -286,119 +282,119 @@ mod tests {
     #[test]
     fn declaring_variable_with_array_literal() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     var arr = []int{ 1 };
-                end
+                }
             "});
     }
 
     #[test]
     fn declaring_variable_with_empty_array_literal() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     var arr = []int{};
-                end
+                }
             "});
     }
 
     #[test]
     fn declaring_variable_with_array_type_notation() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     var arr: []int = []int{ 5, 9, 10 };
-                end
+                }
             "});
     }
 
     #[test]
     fn declaring_variable_with_empty_array_literal_and_type_notation() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     var arr: []int = []int{};
-                end
+                }
             "});
     }
 
     #[test]
     fn declaring_variable_with_incompatible_array_literal() {
         assert_is_err(indoc! {"
-                fn main() do
+                fn main() {
                     var arr: []int = []short{ 5 };
-                end
+                }
             "});
     }
 
     #[test]
     fn declaring_variable_with_nested_arrays_and_type_notation() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     var arr: [][]int = [][]int{ []int{5, 9, 10}, []int{1, 2, 3} };
-                end
+                }
             "});
     }
 
     #[test]
     fn declaring_variable_with_nested_empty_arrays_and_type_notation() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     var arr: [][][]int = [][][]int{ [][]int{}, [][]int{} };
-                end
+                }
             "});
     }
 
     #[test]
     fn declaring_variables_of_sbyte_array() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     var arr: []sbyte = []sbyte{};
 
                     var arr2: []sbyte = []sbyte{ 1, 2, 3 };
-                end
+                }
             "});
     }
 
     #[test]
     fn declaring_variables_of_long_array_with_math_expr_in_literal() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     var x: long = 10;
                     var arr: []long = []long{ 1, 2, 3 + x };
-                end
+                }
             "});
     }
 
     #[test]
     fn declaring_variable_with_array_literal_of_function_types() {
         assert_is_ok(indoc! {"
-                fn main() do
+                fn main() {
                     var arr = []()->int{ five, six };
-                end
+                }
 
-                fn five(): int do
+                fn five(): int {
                     return 5;
-                end
+                }
 
-                fn six(): int do
+                fn six(): int {
                     return 6;
-                end
+                }
             "});
     }
 
     #[test]
     fn declaring_variable_with_incompatible_element_types() {
         assert_is_err(indoc! {"
-                fn main() do
+                fn main() {
                     var arr = []int{ 1, 0.5, };
-                end
+                }
             "});
     }
 
     #[test]
     fn declaring_variable_with_non_existing_array_type() {
         assert_is_err(indoc! {"
-                fn main() do
+                fn main() {
                     var arr = []NotExist{};
-                end
+                }
             "})
     }
 }

--- a/compiler/src/semantic/while_loop.rs
+++ b/compiler/src/semantic/while_loop.rs
@@ -14,19 +14,19 @@ use crate::ast::AstNode;
 /// * The provided condition must be an expression that returns a boolean:
 ///
 /// ```text
-/// while true do
+/// while true {
 ///     # ...
-/// end
+/// }
 /// ```
 ///
 /// * With `break` or `continue` statement:
 ///
 /// ```text
-/// while true do
-///     if !false do
+/// while true {
+///     if !false {
 ///         break;
-///     end
-/// end
+///     }
+/// }
 /// ```
 ///
 /// ### ❌ Invalid Examples
@@ -35,9 +35,9 @@ use crate::ast::AstNode;
 ///   boolean:
 ///
 /// ```text
-/// while 1 + 1 do
+/// while 1 + 1 {
 ///     # Invalid
-/// end
+/// }
 /// ```
 pub struct WhileLoopAnalyzer<'a> {
     node: &'a AstNode,

--- a/compiler/src/semantic/while_loop.rs
+++ b/compiler/src/semantic/while_loop.rs
@@ -83,51 +83,51 @@ mod tests {
     #[test]
     fn while_loop_statements() {
         assert_is_ok(indoc! {"
-                fn main() do
-                    while 2 > 5 do
+                fn main() {
+                    while 2 > 5 {
                         debug 1;
-                    end
+                    }
 
                     var a = 5;
-                    while true do
-                        if a == 5 do
+                    while true {
+                        if a == 5 {
                             break;
-                        end
+                        }
                         debug 0;
-                    end
-                end
+                    }
+                }
             "})
     }
 
     #[test]
     fn using_math_expression_as_condition_in_while_statement() {
         assert_is_err(indoc! {"
-                fn main() do
-                    while 5 + 5 do end
-                end
+                fn main() {
+                    while 5 + 5 {}
+                }
             "})
     }
 
     #[test]
     fn using_break_statement_not_in_loop_scope() {
         assert_is_err(indoc! {"
-                fn main() do
-                    if true do
+                fn main() {
+                    if true {
                         break;
-                    end
-                end
+                    }
+                }
             "})
     }
 
     #[test]
     fn using_invalid_statement_after_loop_control() {
         assert_is_err(indoc! {"
-                fn main() do
-                    while true do
+                fn main() {
+                    while true {
                         break;
                         1 + true; // this should be error
-                    end
-                end
+                    }
+                }
             "})
     }
 }

--- a/docs/examples/fibonacci.kaba
+++ b/docs/examples/fibonacci.kaba
@@ -1,15 +1,15 @@
 // A simple fibonacci implementation
 
-fn main() do
+fn main() {
     debug fibonacci(6);
-end
+}
 
-fn fibonacci(n: int): int do
-    if n <= 0 do
+fn fibonacci(n: int): int {
+    if n <= 0 {
         return 0;
-    else if n == 1 || n == 2 do
+    } else if n == 1 || n == 2 {
         return 1;
-    end
+    }
 
     return fibonacci(n-1) + fibonacci(n-2);
-end
+}

--- a/docs/examples/hello_world.kaba
+++ b/docs/examples/hello_world.kaba
@@ -1,5 +1,5 @@
 // Display "Hello, World!" in the screen
 
-fn main() do
+fn main() {
     debug "Hello, world!";
-end
+}

--- a/docs/examples/odd_numbers.kaba
+++ b/docs/examples/odd_numbers.kaba
@@ -1,13 +1,13 @@
 // Display all positive odd numbers below 0.
 
-fn main() do
+fn main() {
     var i = 0;
 
-    while i < 10 do
-        if i % 2 == 1 do
+    while i < 10 {
+        if i % 2 == 1 {
             debug i;
-        end
+        }
 
         i += 1;
-    end
-end
+    }
+}

--- a/docs/examples/print_array.kaba
+++ b/docs/examples/print_array.kaba
@@ -1,9 +1,9 @@
 // Display elements inside an array
 
-fn main() do
+fn main() {
     var arr = []int{ 1, 2, 3, 4, 5, 6 };
 
-    each n in arr do
+    each n in arr {
         debug n * 2;
-    end
-end
+    }
+}

--- a/docs/examples/swap_variables.kaba
+++ b/docs/examples/swap_variables.kaba
@@ -1,6 +1,6 @@
 // Swap the value between 2 variables
 
-fn main() do
+fn main() {
     var x = 10;
     var y = 20;
 
@@ -13,4 +13,4 @@ fn main() do
 
     debug x;
     debug y;
-end
+}

--- a/docs/features.md
+++ b/docs/features.md
@@ -52,9 +52,9 @@ Kaba only supports single-line comment, which is prefixed by the `//` symbol:
 To define functions, use the `fn` keyword:
 
 ```text
-fn foo() do
+fn foo() {
     // do nothing
-end
+}
 ```
 
 From the example above, `foo()` return type is `void` (not returning anything).
@@ -62,9 +62,9 @@ From the example above, `foo()` return type is `void` (not returning anything).
 To return a value from functions, use the `return` keyword (and don't forget to specify the type notation as well):
 
 ```text
-fn yield_five(): int do
+fn yield_five(): int {
     return 5;
-end
+}
 ```
 
 ## `main()` function
@@ -72,12 +72,11 @@ end
 The entry point to a Kaba program is a function called `main()`:
 
 ```text
-fn main() do
+fn main() {
     do_nothing();
-end
+}
 
-fn do_nothing() do
-end
+fn do_nothing() {}
 ```
 
 ## Creating variables
@@ -85,9 +84,9 @@ end
 To create variables, use the `var` keyword:
 
 ```text
-fn main() do
+fn main() {
     var x = 5;
-end
+}
 ```
 
 The value must always be specified, while the variable's type can be inferred from it.
@@ -95,17 +94,17 @@ The value must always be specified, while the variable's type can be inferred fr
 If you want to specify the type manually, use the following syntax:
 
 ```text
-fn main() do
+fn main() {
     var x: int = 5;
-end
+}
 ```
 
 If value type is incompatible with the variable, the compiler will throw an error:
 
 ```text
-fn main() do
+fn main() {
     var x: int = 10.0;  // ERROR
-end
+}
 ```
 
 ## Value assignments
@@ -115,11 +114,11 @@ Kaba is a strongly-typed language, so the type of operands in various operations
 For example, the following program will results in compilation error:
 
 ```text
-fn main() do
+fn main() {
     var x = 5;
 
     x = 10.0;   // ERROR!
-end
+}
 ```
 
 ## Shorthand assignments
@@ -127,7 +126,7 @@ end
 Shorthand assignments are also supported:
 
 ```text
-fn main() do
+fn main() {
     var x = 10;
 
     x += 1;
@@ -135,7 +134,7 @@ fn main() do
     x *= 2;
     x /= 4;
     x %= 2;
-end
+}
 ```
 
 ## Displaying value with `debug` statement
@@ -143,22 +142,22 @@ end
 To display value to `stdout`, use the `debug` statement:
 
 ```text
-fn main() do
+fn main() {
     var x = 101;
 
     debug x;
-end
+}
 ```
 
 Note that the compiler will reject if the expression evaluates to `void` type:
 
 ```text
-fn main() do
+fn main() {
     debug my_void_fn();  // ERROR
-end
+}
 
-fn my_void_fn() do
-end
+fn my_void_fn() {
+}
 ```
 
 ## Data types
@@ -190,7 +189,7 @@ Currently, Kaba only support these (non-`void`) data types:
 (... more to come!)
 
 ```text
-fn main() do
+fn main() {
     var a: int = 10;
 
     var b: float = 5.0;
@@ -204,10 +203,9 @@ fn main() do
     var f: () -> void = foo;
 
     var g: []int = []int{ 99, 101 };
-end
+}
 
-fn foo() do
-end
+fn foo() {}
 ```
 
 ### About `char` type
@@ -239,29 +237,29 @@ Because the size is not included in the type notation, an integer array like `[1
 Kaba can infer the type of an array:
 
 ```text
-fn main do
+fn main {
     var arr = []bool{ false, true, true };
 
     // The type of `arr` is `[]bool`
 
     debug arr[1];   // `true`
-end
+}
 ```
 
 More complex scenarios are also supported:
 
 ```text
-fn main() do
+fn main() {
     var arr = [][]int{ []int{}, []int{ 4, 5 } };
     foo(arr);
 
     arr[1][1] = 10;
     foo(arr);
-end
+}
 
-fn foo(arr: [][]int) do
+fn foo(arr: [][]int) {
     debug arr[1][1];
-end
+}
 ```
 
 ## Expressions
@@ -271,11 +269,11 @@ end
 Basic math operations such as addition, subtraction, etc. are supported:
 
 ```text
-fn main() do
+fn main() {
     debug 23 + 5 * 30 / (2 - 9);
 
     debug 5 % 2;
-end
+}
 ```
 
 ### Equality and comparison expressions
@@ -283,14 +281,14 @@ end
 Operations like "less than", "equal", etc. are supported:
 
 ```text
-fn main() do
+fn main() {
     debug 50 == 50;
     debug 50 != 10;
     debug 43 > 2;
     debug 2.5 >= 2.5;
     debug 100 < 101;
     debug 7 <= 10;
-end
+}
 ```
 
 ### Logical boolean expressions
@@ -298,11 +296,11 @@ end
 Logical "or", "and", and "not" are supported:
 
 ```text
-fn main() do
+fn main() {
     debug false || true;
     debug false && false;
     debug !false;
-end
+}
 ```
 
 ## Conditional branches
@@ -310,19 +308,19 @@ end
 Kaba also support "if... else..." statement:
 
 ```text
-fn main() do
+fn main() {
     var condition = 50 > 10;
     var condition2 = 50 > 20;
 
-    if condition do
+    if condition {
         debug 1;
-        if condition2 do
+        if condition2 {
             debug 2;
-        end
-    else do
+        }
+    } else {
         debug 0;
-    end
-end
+    }
+}
 ```
 
 ## Loop with `while` statement
@@ -330,48 +328,48 @@ end
 To looping over while a condition is met, use the `while` statement:
 
 ```text
-fn main() do
+fn main() {
     var i = 0;
 
-    while i < 10 do
-        if i % 2 == 0 do
+    while i < 10 {
+        if i % 2 == 0 {
             debug i;
-        end
+        }
         i += 1;
-    end
-end
+    }
+}
 ```
 
 To exit from a loop early, use the `break` statement:
 
 ```text
-fn main() do
+fn main() {
     var i = 0;
 
-    while i < 10 do
-        if i == 5 do
+    while i < 10 {
+        if i == 5 {
             break;  // exit from loop
-        end
+        }
         debug i;
         i += 1;
-    end
-end
+    }
+}
 ```
 
 To skip an iteration, use the `continue` statement:
 
 ```text
-fn main() do
+fn main() {
     var i = 0;
 
-    while i < 10 do
+    while i < 10 {
         i += 1;
-        if i == 5 do
+        if i == 5 {
             continue;  // "5" won't be printed
-        end
+        }
         debug i;
-    end
-end
+    }
+}
 ```
 
 ## Loop with `each` statement
@@ -379,27 +377,27 @@ end
 To loop over each element of an iterable, use the `each` loop statement:
 
 ```text
-fn main() do
-    each n in []int{ 1, 2, 3, 4 } do
+fn main() {
+    each n in []int{ 1, 2, 3, 4 } {
         debug n * 2;
-    end
-end
+    }
+}
 ```
 
 It also supports `continue` and `break` statements:
 
 ```text
-fn main() do
-    each n in []int{ 1, 2, 3, 4, 5, 6 } do
-        if n == 3 do
+fn main() {
+    each n in []int{ 1, 2, 3, 4, 5, 6 } {
+        if n == 3 {
             continue;
-        end
+        }
 
-        if n == 5 do
+        if n == 5 {
             break;
-        end
+        }
 
         debug n;
-    end
-end
+    }
+}
 ```

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -84,10 +84,10 @@ mod tests {
     fn simple_outputting() {
         assert_output_equal(
             indoc! {"
-                fn main() do
+                fn main() {
                     var x = 10;
                     debug x;
-                end
+                }
             "},
             "10\n".as_bytes(),
         );
@@ -97,12 +97,12 @@ mod tests {
     fn multiplication_result() {
         assert_output_equal(
             indoc! {"
-                fn main() do
+                fn main() {
                     var x = 5;
                     var y = 10;
 
                     debug x * y;
-                end
+                }
             "},
             "50\n".as_bytes(),
         );
@@ -112,13 +112,13 @@ mod tests {
     fn changing_value() {
         assert_output_equal(
             indoc! {"
-                fn main() do
+                fn main() {
                     var x = 2048;
                     debug x;
 
                     x = 1024;
                     debug x;
-                end
+                }
             "},
             "2048\n1024\n".as_bytes(),
         );
@@ -128,14 +128,14 @@ mod tests {
     fn conditional_branch() {
         assert_output_equal(
             indoc! {"
-                fn main() do
+                fn main() {
                     var x = 2048;
-                    if true do
+                    if true {
                         var x = 1024;
                         debug x;
-                    end
+                    }
                     debug x;
-                end
+                }
             "},
             "1024\n2048\n".as_bytes(),
         );
@@ -145,17 +145,17 @@ mod tests {
     fn multiple_conditional_branches() {
         assert_output_equal(
             indoc! {"
-                fn main() do
+                fn main() {
                     var x = 2048;
-                    if false do
+                    if false {
                         x = 1024;
-                    else if false do
+                    } else if false {
                         x = 512;
-                    else do
+                    } else {
                         x = 256;
-                    end
+                    }
                     debug x;
-                end
+                }
             "},
             "256\n".as_bytes(),
         );
@@ -165,16 +165,16 @@ mod tests {
     fn simple_loop() {
         assert_output_equal(
             indoc! {"
-                fn main() do
+                fn main() {
                     var x = 0;
-                    while true do
+                    while true {
                         debug x;
-                        if x == 5 do
+                        if x == 5 {
                             break;
-                        end
+                        }
                         x = x + 1;
-                    end
-                end
+                    }
+                }
             "},
             "0\n1\n2\n3\n4\n5\n".as_bytes(),
         );
@@ -184,17 +184,17 @@ mod tests {
     fn boolean_logic_operators() {
         assert_output_equal(
             indoc! {"
-                fn main() do
-                    if false && true do
+                fn main() {
+                    if false && true {
                         debug 1;
-                    end
-                    if false || true do
+                    }
+                    if false || true {
                         debug 2;
-                    end
-                    if !false do
+                    }
+                    if !false {
                         debug 3;
-                    end
-                end
+                    }
+                }
             "},
             "2\n3\n".as_bytes(),
         );
@@ -204,18 +204,18 @@ mod tests {
     fn loop_with_conditional_branches() {
         assert_output_equal(
             indoc! {"
-                fn main() do
+                fn main() {
                     var x = 0;
-                    while true do
+                    while true {
                         x = x + 1;
-                        if x == 2 do
+                        if x == 2 {
                             continue;
-                        else if x == 5 do
+                        } else if x == 5 {
                             break;
-                        end
+                        }
                         debug x;
-                    end
-                end
+                    }
+                }
             "},
             "1\n3\n4\n".as_bytes(),
         );
@@ -225,7 +225,7 @@ mod tests {
     fn shorthand_operators() {
         assert_output_equal(
             indoc! {"
-                fn main() do
+                fn main() {
                     var x = 5;
                     x += 5;
                     debug x;
@@ -237,7 +237,7 @@ mod tests {
                     debug x;
                     x %= 3;
                     debug x;
-                end
+                }
             "},
             "10\n8\n16\n4\n1\n".as_bytes(),
         );
@@ -247,17 +247,17 @@ mod tests {
     fn function_call() {
         assert_output_equal(
             indoc! {"
-                fn main() do
+                fn main() {
                     debug add_two(5);
-                end
+                }
 
-                fn add_two(n: int): int do
+                fn add_two(n: int): int {
                     return n + get_two();
-                end
+                }
 
-                fn get_two(): int do
+                fn get_two(): int {
                     return 2;
-                end
+                }
             "},
             "7\n".as_bytes(),
         );
@@ -267,14 +267,14 @@ mod tests {
     fn calling_function_with_variable_argument() {
         assert_output_equal(
             indoc! {"
-                fn main() do
+                fn main() {
                     var x = 10;
                     dbg(x);
-                end
+                }
 
-                fn dbg(n: int) do
+                fn dbg(n: int) {
                     debug n;
-                end
+                }
             "},
             "10\n".as_bytes(),
         );
@@ -284,17 +284,17 @@ mod tests {
     fn doing_math_on_function_call_results() {
         assert_output_equal(
             indoc! {"
-                fn main() do
+                fn main() {
                     debug one() + two();
-                end
+                }
 
-                fn one(): int do
+                fn one(): int {
                     return 1;
-                end
+                }
 
-                fn two(): int do
+                fn two(): int {
                     return 2;
-                end
+                }
             "},
             "3\n".as_bytes(),
         );
@@ -304,15 +304,15 @@ mod tests {
     fn function_accept_string_parameter_and_return_value() {
         assert_output_equal(
             indoc! {r#"
-                fn main() do
+                fn main() {
                     debug greet("snaztoz");
-                end
+                }
 
-                fn greet(name: string): string do
+                fn greet(name: string): string {
                     debug "Hello";
                     debug name;
                     return name;
-                end
+                }
             "#},
             "Hello\nsnaztoz\nsnaztoz\n".as_bytes(),
         );
@@ -322,16 +322,16 @@ mod tests {
     fn recursion() {
         assert_output_equal(
             indoc! {"
-                fn main() do
+                fn main() {
                     debug fibonacci(3);
-                end
+                }
 
-                fn fibonacci(n: int): int do
-                    if n == 1 || n == 2 do
+                fn fibonacci(n: int): int {
+                    if n == 1 || n == 2 {
                         return 1;
-                    end
+                    }
                     return fibonacci(n-1) + fibonacci(n-2);
-                end
+                }
             "},
             "2\n".as_bytes(),
         );
@@ -341,17 +341,17 @@ mod tests {
     fn recursive_counter() {
         assert_output_equal(
             indoc! {"
-                fn main() do
+                fn main() {
                     count_to_zero(5);
-                end
+                }
 
-                fn count_to_zero(n: int) do
-                    if n < 0 do
+                fn count_to_zero(n: int) {
+                    if n < 0 {
                         return;
-                    end
+                    }
                     debug n;
                     count_to_zero(n-1);
-                end
+                }
             "},
             "5\n4\n3\n2\n1\n0\n".as_bytes(),
         );
@@ -361,21 +361,21 @@ mod tests {
     fn function_as_argument_to_function_call() {
         assert_output_equal(
             indoc! {"
-                fn main() do
+                fn main() {
                     print(produce);
-                end
+                }
 
-                fn print(producer: () -> int) do
+                fn print(producer: () -> int) {
                     var x: () -> int = producer;
                     debug x();
 
                     var y = producer;
                     debug y();
-                end
+                }
 
-                fn produce(): int do
+                fn produce(): int {
                     return 5;
-                end
+                }
             "},
             "5\n5\n".as_bytes(),
         );
@@ -385,17 +385,17 @@ mod tests {
     fn calling_function_returned_from_another_function_call() {
         assert_output_equal(
             indoc! {"
-                fn main() do
+                fn main() {
                     debug foo()();
-                end
+                }
 
-                fn foo(): () -> int do
+                fn foo(): () -> int {
                     return bar;
-                end
+                }
 
-                fn bar(): int do
+                fn bar(): int {
                     return 25;
-                end
+                }
             "},
             "25\n".as_bytes(),
         );
@@ -405,13 +405,13 @@ mod tests {
     fn debug_array() {
         assert_output_equal(
             indoc! {"
-                fn main() do
+                fn main() {
                     debug [][]int{ []int{1, 2}, []int{3, 4} }[1][0];
 
                     var arr = []int{ 1, 3 };
                     var x = 98;
                     debug arr[99 - x] + 5;
-                end
+                }
             "},
             "3\n8\n".as_bytes(),
         );
@@ -421,7 +421,7 @@ mod tests {
     fn assign_to_array() {
         assert_output_equal(
             indoc! {"
-                fn main() do
+                fn main() {
                     var arr = []int{ 0, 1, 2 };
 
                     arr[0] = 99;
@@ -435,7 +435,7 @@ mod tests {
                     debug arr[0];
                     debug arr[1];
                     debug arr[2];
-                end
+                }
             "},
             "0\n4\n2\n".as_bytes(),
         );
@@ -445,7 +445,7 @@ mod tests {
     fn calling_array_elements() {
         assert_output_equal(
             indoc! {"
-                fn main() do
+                fn main() {
                     var arr = [](int) -> int {
                         add_one,
                         add_two,
@@ -453,23 +453,23 @@ mod tests {
                     };
 
                     var i = 0;
-                    while i < 3 do
+                    while i < 3 {
                         debug arr[i](5);
                         i += 1;
-                    end
-                end
+                    }
+                }
 
-                fn add_one(n: int): int do
+                fn add_one(n: int): int {
                     return n + 1;
-                end
+                }
 
-                fn add_two(n: int): int do
+                fn add_two(n: int): int {
                     return n + 2;
-                end
+                }
 
-                fn add_three(n: int): int do
+                fn add_three(n: int): int {
                     return n + 3;
-                end
+                }
             "},
             "6\n7\n8\n".as_bytes(),
         );
@@ -479,7 +479,7 @@ mod tests {
     fn returning_array_from_a_function() {
         assert_output_equal(
             indoc! {"
-                fn main() do
+                fn main() {
                     var arr_1 = foo();
                     var arr_2 = foo();
 
@@ -490,11 +490,11 @@ mod tests {
 
                     debug arr_1[0];
                     debug arr_2[0];
-                end
+                }
 
-                fn foo(): []int do
+                fn foo(): []int {
                     return []int{ 0 };
-                end
+                }
             "},
             "0\n0\n10\n0\n".as_bytes(),
         );
@@ -504,19 +504,19 @@ mod tests {
     fn iterate_array_using_each_loop_statement() {
         assert_output_equal(
             indoc! {"
-                fn main() do
-                    each n in []int{ 1, 2, 3, 4, 5, 6 } do
-                        if n == 3 do
+                fn main() {
+                    each n in []int{ 1, 2, 3, 4, 5, 6 } {
+                        if n == 3 {
                             continue;
-                        end
+                        }
 
-                        if n == 5 do
+                        if n == 5 {
                             break;
-                        end
+                        }
 
                         debug n * 2;
-                    end
-                end
+                    }
+                }
             "},
             "2\n4\n8\n".as_bytes(),
         );


### PR DESCRIPTION
Block delimiters are changed from `do ... end` to `{ ... }`.