### PR TITLE
Change array literal syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change array literal syntax.
+
 ## [0.5.0] - 2025-01-01
 
 ### Added

--- a/compiler/src/semantic/assignment.rs
+++ b/compiler/src/semantic/assignment.rs
@@ -236,7 +236,7 @@ mod tests {
     fn assign_to_array_element() {
         assert_is_ok(indoc! {"
                 fn main() {
-                    var arr = []bool{ true, false, true };
+                    var arr = [bool true, false, true];
 
                     arr[1] = true;
                 }
@@ -247,7 +247,7 @@ mod tests {
     fn shorthand_assign_to_array_element() {
         assert_is_ok(indoc! {"
                 fn main() {
-                    var arr = []float{ 0.5, 1.1, 2.3 };
+                    var arr = [float 0.5, 1.1, 2.3];
 
                     arr[0] += 5.5;
                 }

--- a/compiler/src/semantic/each_loop.rs
+++ b/compiler/src/semantic/each_loop.rs
@@ -14,7 +14,7 @@ use crate::ast::AstNode;
 /// * The provided expression must evaluates to an array:
 ///
 /// ```text
-/// each n in []int{ 0, 1, 2 } {
+/// each n in [int 0, 1, 2] {
 ///     // ...
 /// }
 /// ```
@@ -22,7 +22,7 @@ use crate::ast::AstNode;
 /// * With `break` or `continue` statement:
 ///
 /// ```text
-/// each n in []int{ 0, 1, 2 } {
+/// each n in [int 0, 1, 2] {
 ///     if !false {
 ///         break;
 ///     }
@@ -97,11 +97,11 @@ mod tests {
     fn each_loop_statements() {
         assert_is_ok(indoc! {"
                 fn main() {
-                    each n in []int{1, 2, 3} {
+                    each n in [int 1, 2, 3] {
                         debug n;
                     }
 
-                    var arr = []int{4, 5, 6};
+                    var arr = [int 4, 5, 6];
                     each n in arr {
                         debug n;
                     }
@@ -124,7 +124,7 @@ mod tests {
     fn accessing_elem_id_outside_scope() {
         assert_is_err(indoc! {"
                 fn main() {
-                    each n in []int{1, 2} {}
+                    each n in [int 1, 2] {}
 
                     debug n;
                 }

--- a/compiler/src/semantic/expression/index_access.rs
+++ b/compiler/src/semantic/expression/index_access.rs
@@ -60,7 +60,7 @@ mod tests {
     #[test]
     fn index_accessing() {
         assert_expr_type(
-            "[][]int{ []int{ 1, 2 } }[0];",
+            "[[]int [int 1, 2]][0];",
             &[],
             Type::Array {
                 elem_t: Box::new(Type::Int(IntType::Int)),

--- a/compiler/src/semantic/function.rs
+++ b/compiler/src/semantic/function.rs
@@ -389,7 +389,7 @@ mod tests {
     fn calling_function_with_array_parameter() {
         assert_is_ok(indoc! {"
                 fn main() {
-                    foo([]int{1, 2, 3});
+                    foo([int 1, 2, 3]);
                 }
 
                 fn foo(arr: []int) {
@@ -401,11 +401,11 @@ mod tests {
     fn calling_function_with_array_parameter_using_different_array_sizes() {
         assert_is_ok(indoc! {"
                 fn main() {
-                    foo([]int{1, 2, 3});
+                    foo([int 1, 2, 3]);
 
-                    foo([]int{});
+                    foo([int]);
 
-                    foo([]int{1,});
+                    foo([int 1]);
                 }
 
                 fn foo(arr: []int) {
@@ -424,7 +424,7 @@ mod tests {
                 }
 
                 fn foo(): []int {
-                    return []int{1, 2, 3};
+                    return [int 1, 2, 3];
                 }
             "});
     }

--- a/compiler/src/semantic/literal.rs
+++ b/compiler/src/semantic/literal.rs
@@ -63,7 +63,7 @@ mod tests {
     #[test]
     fn array_literal() {
         assert_expr_type(
-            "[]int{ 1, 2, 3 };",
+            "[int 1, 2, 3];",
             &[],
             Type::Array {
                 elem_t: Box::new(Type::Int(IntType::Int)),
@@ -74,7 +74,7 @@ mod tests {
     #[test]
     fn empty_array_literal() {
         assert_expr_type(
-            "[]int{};",
+            "[int];",
             &[],
             Type::Array {
                 elem_t: Box::new(Type::Int(IntType::Int)),
@@ -85,7 +85,7 @@ mod tests {
     #[test]
     fn array_literal_with_math_expression() {
         assert_expr_type(
-            "[]int{ 8 * 2048 };",
+            "[int 8 * 2048];",
             &[],
             Type::Array {
                 elem_t: Box::new(Type::Int(IntType::Int)),
@@ -96,13 +96,13 @@ mod tests {
     #[test]
     fn array_literal_with_incompatible_type() {
         let symbols = [("x", Type::Int(IntType::Short))];
-        assert_expr_is_err("[]int{ 1, x, 5 };", &symbols);
+        assert_expr_is_err("[int 1, x, 5];", &symbols);
     }
 
     #[test]
     fn nested_array_literals() {
         assert_expr_type(
-            "[][]int{ []int{1, 3, 5}, []int{2, 6, 3}, []int{9, 1, 1} };",
+            "[[]int [int 1, 3, 5], [int 2, 6, 3], [int 9, 1, 1]];",
             &[],
             Type::Array {
                 elem_t: Box::new(Type::Array {
@@ -114,13 +114,13 @@ mod tests {
 
     #[test]
     fn array_literal_with_different_element_types() {
-        assert_expr_is_err("[]int{ 1, 5.0 };", &[]);
+        assert_expr_is_err("[int 1, 5.0];", &[]);
     }
 
     #[test]
     fn array_literal_with_different_nested_element_sizes() {
         assert_expr_type(
-            "[][]int{ []int{}, []int{1} };",
+            "[[]int [int], [int 1]];",
             &[],
             Type::Array {
                 elem_t: Box::new(Type::Array {

--- a/compiler/src/semantic/variable.rs
+++ b/compiler/src/semantic/variable.rs
@@ -283,7 +283,7 @@ mod tests {
     fn declaring_variable_with_array_literal() {
         assert_is_ok(indoc! {"
                 fn main() {
-                    var arr = []int{ 1 };
+                    var arr = [int 1];
                 }
             "});
     }
@@ -292,7 +292,7 @@ mod tests {
     fn declaring_variable_with_empty_array_literal() {
         assert_is_ok(indoc! {"
                 fn main() {
-                    var arr = []int{};
+                    var arr = [int];
                 }
             "});
     }
@@ -301,7 +301,7 @@ mod tests {
     fn declaring_variable_with_array_type_notation() {
         assert_is_ok(indoc! {"
                 fn main() {
-                    var arr: []int = []int{ 5, 9, 10 };
+                    var arr: []int = [int 5, 9, 10];
                 }
             "});
     }
@@ -310,7 +310,7 @@ mod tests {
     fn declaring_variable_with_empty_array_literal_and_type_notation() {
         assert_is_ok(indoc! {"
                 fn main() {
-                    var arr: []int = []int{};
+                    var arr: []int = [int];
                 }
             "});
     }
@@ -319,7 +319,7 @@ mod tests {
     fn declaring_variable_with_incompatible_array_literal() {
         assert_is_err(indoc! {"
                 fn main() {
-                    var arr: []int = []short{ 5 };
+                    var arr: []int = [short 5];
                 }
             "});
     }
@@ -328,7 +328,7 @@ mod tests {
     fn declaring_variable_with_nested_arrays_and_type_notation() {
         assert_is_ok(indoc! {"
                 fn main() {
-                    var arr: [][]int = [][]int{ []int{5, 9, 10}, []int{1, 2, 3} };
+                    var arr: [][]int = [[]int [int 5, 9, 10], [int 1, 2, 3]];
                 }
             "});
     }
@@ -337,7 +337,7 @@ mod tests {
     fn declaring_variable_with_nested_empty_arrays_and_type_notation() {
         assert_is_ok(indoc! {"
                 fn main() {
-                    var arr: [][][]int = [][][]int{ [][]int{}, [][]int{} };
+                    var arr: [][][]int = [[][]int [[]int], [[]int]];
                 }
             "});
     }
@@ -346,9 +346,9 @@ mod tests {
     fn declaring_variables_of_sbyte_array() {
         assert_is_ok(indoc! {"
                 fn main() {
-                    var arr: []sbyte = []sbyte{};
+                    var arr: []sbyte = [sbyte];
 
-                    var arr2: []sbyte = []sbyte{ 1, 2, 3 };
+                    var arr2: []sbyte = [sbyte 1, 2, 3];
                 }
             "});
     }
@@ -358,7 +358,7 @@ mod tests {
         assert_is_ok(indoc! {"
                 fn main() {
                     var x: long = 10;
-                    var arr: []long = []long{ 1, 2, 3 + x };
+                    var arr: []long = [long 1, 2, 3 + x];
                 }
             "});
     }
@@ -367,7 +367,7 @@ mod tests {
     fn declaring_variable_with_array_literal_of_function_types() {
         assert_is_ok(indoc! {"
                 fn main() {
-                    var arr = []()->int{ five, six };
+                    var arr = [()->int five, six];
                 }
 
                 fn five(): int {
@@ -384,7 +384,7 @@ mod tests {
     fn declaring_variable_with_incompatible_element_types() {
         assert_is_err(indoc! {"
                 fn main() {
-                    var arr = []int{ 1, 0.5, };
+                    var arr = [int 1, 0.5];
                 }
             "});
     }
@@ -393,7 +393,7 @@ mod tests {
     fn declaring_variable_with_non_existing_array_type() {
         assert_is_err(indoc! {"
                 fn main() {
-                    var arr = []NotExist{};
+                    var arr = [NotExist];
                 }
             "})
     }

--- a/docs/examples/print_array.kaba
+++ b/docs/examples/print_array.kaba
@@ -1,7 +1,7 @@
 // Display elements inside an array
 
 fn main() {
-    var arr = []int{ 1, 2, 3, 4, 5, 6 };
+    var arr = [int 1, 2, 3, 4, 5, 6];
 
     each n in arr {
         debug n * 2;

--- a/docs/features.md
+++ b/docs/features.md
@@ -156,8 +156,7 @@ fn main() {
     debug my_void_fn();  // ERROR
 }
 
-fn my_void_fn() {
-}
+fn my_void_fn() {}
 ```
 
 ## Data types
@@ -202,7 +201,7 @@ fn main() {
 
     var f: () -> void = foo;
 
-    var g: []int = []int{ 99, 101 };
+    var g: []int = [int 99, 101];
 }
 
 fn foo() {}
@@ -238,7 +237,7 @@ Kaba can infer the type of an array:
 
 ```text
 fn main {
-    var arr = []bool{ false, true, true };
+    var arr = [bool false, true, true];
 
     // The type of `arr` is `[]bool`
 
@@ -250,7 +249,7 @@ More complex scenarios are also supported:
 
 ```text
 fn main() {
-    var arr = [][]int{ []int{}, []int{ 4, 5 } };
+    var arr = [[]int [int], [int 4, 5]];
     foo(arr);
 
     arr[1][1] = 10;
@@ -323,7 +322,7 @@ fn main() {
 }
 ```
 
-## Loop with `while` statement
+## Looping with `while` statement
 
 To looping over while a condition is met, use the `while` statement:
 
@@ -372,23 +371,23 @@ fn main() {
 }
 ```
 
-## Loop with `each` statement
+## Looping with `each` statement
 
-To loop over each element of an iterable, use the `each` loop statement:
+To simplify looping over elements of an iterable, use the `each` loop statement:
 
 ```text
 fn main() {
-    each n in []int{ 1, 2, 3, 4 } {
+    each n in [int 1, 2, 3, 4] {
         debug n * 2;
     }
 }
 ```
 
-It also supports `continue` and `break` statements:
+Similar to the `while` statement, we can also use `continue` and `break` statements in inside of it:
 
 ```text
 fn main() {
-    each n in []int{ 1, 2, 3, 4, 5, 6 } {
+    each n in [int 1, 2, 3, 4, 5, 6] {
         if n == 3 {
             continue;
         }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -406,9 +406,9 @@ mod tests {
         assert_output_equal(
             indoc! {"
                 fn main() {
-                    debug [][]int{ []int{1, 2}, []int{3, 4} }[1][0];
+                    debug [[]int [int 1, 2], [int 3, 4]][1][0];
 
-                    var arr = []int{ 1, 3 };
+                    var arr = [int 1, 3];
                     var x = 98;
                     debug arr[99 - x] + 5;
                 }
@@ -422,7 +422,7 @@ mod tests {
         assert_output_equal(
             indoc! {"
                 fn main() {
-                    var arr = []int{ 0, 1, 2 };
+                    var arr = [int 0, 1, 2];
 
                     arr[0] = 99;
 
@@ -446,11 +446,11 @@ mod tests {
         assert_output_equal(
             indoc! {"
                 fn main() {
-                    var arr = [](int) -> int {
+                    var arr = [(int) -> int
                         add_one,
                         add_two,
                         add_three,
-                    };
+                    ];
 
                     var i = 0;
                     while i < 3 {
@@ -493,7 +493,7 @@ mod tests {
                 }
 
                 fn foo(): []int {
-                    return []int{ 0 };
+                    return [int 0];
                 }
             "},
             "0\n0\n10\n0\n".as_bytes(),
@@ -505,7 +505,7 @@ mod tests {
         assert_output_equal(
             indoc! {"
                 fn main() {
-                    each n in []int{ 1, 2, 3, 4, 5, 6 } {
+                    each n in [int 1, 2, 3, 4, 5, 6] {
                         if n == 3 {
                             continue;
                         }


### PR DESCRIPTION
Before:

```text
[]int{1, 2, 3}
```

After:

```text
[int 1, 2, 3]
```