### PR TITLE
Change some syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `fn` keyword is replaced with `def` keyword.
+- Make parentheses optional in function definition when it does not receive any parameters.
+
 ## [0.5.3] - 2025-02-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Next, create a [Kaba program file](docs/features.md) (the extension **must be** 
 For this example, let's create a file called `hello.kaba` with the following code:
 
 ```text
-fn main() {
+def main {
     debug "Hello, World!";
 }
 ```
@@ -48,7 +48,7 @@ See [docs/examples](docs/examples) directory for the examples of already-working
 
 ## 🎯 Next Goals
 
-The current priority is to add support for `struct` data type.
+The current priority is to add support for `record` data type.
 
 ## ⚒️ Contributing
 

--- a/docs/examples/fibonacci.kaba
+++ b/docs/examples/fibonacci.kaba
@@ -1,10 +1,10 @@
 // A simple fibonacci implementation
 
-fn main() {
+def main {
     debug fibonacci(6);
 }
 
-fn fibonacci(n: int): int {
+def fibonacci(n: int): int {
     if n <= 0 {
         return 0;
     } else if n == 1 || n == 2 {

--- a/docs/examples/hello_world.kaba
+++ b/docs/examples/hello_world.kaba
@@ -1,5 +1,5 @@
 // Display "Hello, World!" in the screen
 
-fn main() {
+def main {
     debug "Hello, world!";
 }

--- a/docs/examples/odd_numbers.kaba
+++ b/docs/examples/odd_numbers.kaba
@@ -1,6 +1,6 @@
 // Display all positive odd numbers below 0.
 
-fn main() {
+def main {
     var i = 0;
 
     while i < 10 {

--- a/docs/examples/print_array.kaba
+++ b/docs/examples/print_array.kaba
@@ -1,6 +1,6 @@
 // Display elements inside an array
 
-fn main() {
+def main {
     var arr = [int 1, 2, 3, 4, 5, 6];
 
     each n in arr {

--- a/docs/examples/swap_variables.kaba
+++ b/docs/examples/swap_variables.kaba
@@ -1,6 +1,6 @@
 // Swap the value between 2 variables
 
-fn main() {
+def main {
     var x = 10;
     var y = 20;
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -49,10 +49,10 @@ Kaba only supports single-line comment, which is prefixed by the `//` symbol:
 
 ## Defining functions
 
-To define functions, use the `fn` keyword:
+To define functions, use the `def` keyword:
 
 ```text
-fn foo() {
+def foo() {
     // do nothing
 }
 ```
@@ -62,7 +62,15 @@ From the example above, `foo()` return type is `void` (not returning anything).
 To return a value from functions, use the `return` keyword (and don't forget to specify the type notation as well):
 
 ```text
-fn yield_five(): int {
+def yield_five(): int {
+    return 5;
+}
+```
+
+If the function does not receive any parameters, we can omit the parentheses:
+
+```
+def yield_five: int {
     return 5;
 }
 ```
@@ -72,11 +80,11 @@ fn yield_five(): int {
 The entry point to a Kaba program is a function called `main()`:
 
 ```text
-fn main() {
+def main {
     do_nothing();
 }
 
-fn do_nothing() {}
+def do_nothing {}
 ```
 
 ## Creating variables
@@ -84,7 +92,7 @@ fn do_nothing() {}
 To create variables, use the `var` keyword:
 
 ```text
-fn main() {
+def main {
     var x = 5;
 }
 ```
@@ -94,7 +102,7 @@ The value must always be specified, while the variable's type can be inferred fr
 If you want to specify the type manually, use the following syntax:
 
 ```text
-fn main() {
+def main {
     var x: int = 5;
 }
 ```
@@ -102,7 +110,7 @@ fn main() {
 If value type is incompatible with the variable, the compiler will throw an error:
 
 ```text
-fn main() {
+def main {
     var x: int = 10.0;  // ERROR
 }
 ```
@@ -114,7 +122,7 @@ Kaba is a strongly-typed language, so the type of operands in various operations
 For example, the following program will results in compilation error:
 
 ```text
-fn main() {
+def main {
     var x = 5;
 
     x = 10.0;   // ERROR!
@@ -126,7 +134,7 @@ fn main() {
 Shorthand assignments are also supported:
 
 ```text
-fn main() {
+def main {
     var x = 10;
 
     x += 1;
@@ -142,21 +150,21 @@ fn main() {
 To display value to `stdout`, use the `debug` statement:
 
 ```text
-fn main() {
+def main {
     var x = 101;
 
     debug x;
 }
 ```
 
-Note that the compiler will reject if the expression evaluates to `void` type:
+Note that the compiler will reject the program if the expression evaluates to `void` type:
 
 ```text
-fn main() {
-    debug my_void_fn();  // ERROR
+def main {
+    debug my_void_def();  // ERROR
 }
 
-fn my_void_fn() {}
+def my_void_def {}
 ```
 
 ## Data types
@@ -188,7 +196,7 @@ Currently, Kaba only support these (non-`void`) data types:
 (... more to come!)
 
 ```text
-fn main() {
+def main {
     var a: int = 10;
 
     var b: float = 5.0;
@@ -204,7 +212,7 @@ fn main() {
     var g: []int = [int 99, 101];
 }
 
-fn foo() {}
+def foo() {}
 ```
 
 ### About `char` type
@@ -236,7 +244,7 @@ Because the size is not included in the type notation, an integer array like `[1
 Kaba can infer the type of an array:
 
 ```text
-fn main() {
+def main {
     var arr = [bool false, true, true];
 
     // The type of `arr` is `[]bool`
@@ -248,7 +256,7 @@ fn main() {
 More complex scenarios are also supported:
 
 ```text
-fn main() {
+def main {
     var arr = [[]int [int], [int 4, 5]];
     foo(arr);
 
@@ -256,7 +264,7 @@ fn main() {
     foo(arr);
 }
 
-fn foo(arr: [][]int) {
+def foo(arr: [][]int) {
     debug arr[1][1];
 }
 ```
@@ -268,7 +276,7 @@ fn foo(arr: [][]int) {
 Basic math operations such as addition, subtraction, etc. are supported:
 
 ```text
-fn main() {
+def main {
     debug 23 + 5 * 30 / (2 - 9);
 
     debug 5 % 2;
@@ -280,7 +288,7 @@ fn main() {
 Operations like "less than", "equal", etc. are supported:
 
 ```text
-fn main() {
+def main {
     debug 50 == 50;
     debug 50 != 10;
     debug 43 > 2;
@@ -295,7 +303,7 @@ fn main() {
 Logical "or", "and", and "not" are supported:
 
 ```text
-fn main() {
+def main {
     debug false || true;
     debug false && false;
     debug !false;
@@ -307,7 +315,7 @@ fn main() {
 Kaba also support "if... else..." statement:
 
 ```text
-fn main() {
+def main {
     var condition = 50 > 10;
     var condition2 = 50 > 20;
 
@@ -327,7 +335,7 @@ fn main() {
 To looping over while a condition is met, use the `while` statement:
 
 ```text
-fn main() {
+def main {
     var i = 0;
 
     while i < 10 {
@@ -342,7 +350,7 @@ fn main() {
 To exit from a loop early, use the `break` statement:
 
 ```text
-fn main() {
+def main {
     var i = 0;
 
     while i < 10 {
@@ -358,7 +366,7 @@ fn main() {
 To skip an iteration, use the `continue` statement:
 
 ```text
-fn main() {
+def main {
     var i = 0;
 
     while i < 10 {
@@ -376,7 +384,7 @@ fn main() {
 To simplify looping over elements of an iterable, use the `each` loop statement:
 
 ```text
-fn main() {
+def main {
     each n in [int 1, 2, 3, 4] {
         debug n * 2;
     }
@@ -386,7 +394,7 @@ fn main() {
 Similar to the `while` statement, we can also use `continue` and `break` statements in inside of it:
 
 ```text
-fn main() {
+def main {
     each n in [int 1, 2, 3, 4, 5, 6] {
         if n == 3 {
             continue;

--- a/kaba2js/src/lib.rs
+++ b/kaba2js/src/lib.rs
@@ -284,7 +284,7 @@ mod tests {
 
     #[test]
     fn main_function() {
-        let result = compile("fn main() {return;}");
+        let result = compile("def main() {return;}");
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), wrap("function main(){return;}"));
@@ -293,7 +293,7 @@ mod tests {
     #[test]
     fn var_declaration_with_literals() {
         let result = compile(indoc! {"
-            fn main() {
+            def main() {
                 var x = 5;
                 var foo = [[]int [int 1, 2, x], [int]];
             }
@@ -309,7 +309,7 @@ mod tests {
     #[test]
     fn var_declaration_with_math_expr() {
         let result = compile(indoc! {"
-            fn main() {
+            def main() {
                 var x = 5;
                 var y = 1 + 5 / x - 2 * 7 % 2;
             }
@@ -326,7 +326,7 @@ mod tests {
     fn char_and_string_val() {
         let result = compile(
             r#"
-            fn main() {
+            def main() {
                 var x = '1';
                 var y = "Hello, World!";
             }
@@ -343,7 +343,7 @@ mod tests {
     #[test]
     fn binary_operations() {
         let result = compile(indoc! {"
-            fn main() {
+            def main() {
                 var x = 5;
                 x += 1;
                 x -= 1;
@@ -364,7 +364,7 @@ mod tests {
     #[test]
     fn conditional_branches() {
         let result = compile(indoc! {"
-            fn main() {
+            def main() {
                 if !false {
                     if false {} else {}
                 } else if true {}
@@ -381,7 +381,7 @@ mod tests {
     #[test]
     fn while_loop() {
         let result = compile(indoc! {"
-            fn main() {
+            def main() {
                 while true {
                     var i = 0;
                     break;
@@ -399,7 +399,7 @@ mod tests {
     #[test]
     fn each_loop() {
         let result = compile(indoc! {"
-            fn main() {
+            def main() {
                 var arr = [int 1, 2, 3];
                 each n in arr {
                     var i = n * 2;
@@ -417,7 +417,7 @@ mod tests {
     #[test]
     fn index_access() {
         let result = compile(indoc! {"
-            fn main() {
+            def main() {
                 var arr = [int 1, 2, 3];
                 arr[0];
             }
@@ -433,11 +433,11 @@ mod tests {
     #[test]
     fn function_call() {
         let result = compile(indoc! {"
-            fn foo(): int {
+            def foo(): int {
                 return 5;
             }
 
-            fn main() {
+            def main() {
                 var x = foo();
             }
         "});
@@ -452,7 +452,7 @@ mod tests {
     #[test]
     fn print_value() {
         let result = compile(indoc! {r#"
-            fn main() {
+            def main() {
                 debug "Hello, World!";
             }
         "#});

--- a/kaba2js/src/lib.rs
+++ b/kaba2js/src/lib.rs
@@ -284,7 +284,7 @@ mod tests {
 
     #[test]
     fn main_function() {
-        let result = compile("def main() {return;}");
+        let result = compile("def main {return;}");
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), wrap("function main(){return;}"));
@@ -293,7 +293,7 @@ mod tests {
     #[test]
     fn var_declaration_with_literals() {
         let result = compile(indoc! {"
-            def main() {
+            def main {
                 var x = 5;
                 var foo = [[]int [int 1, 2, x], [int]];
             }
@@ -309,7 +309,7 @@ mod tests {
     #[test]
     fn var_declaration_with_math_expr() {
         let result = compile(indoc! {"
-            def main() {
+            def main {
                 var x = 5;
                 var y = 1 + 5 / x - 2 * 7 % 2;
             }
@@ -326,7 +326,7 @@ mod tests {
     fn char_and_string_val() {
         let result = compile(
             r#"
-            def main() {
+            def main {
                 var x = '1';
                 var y = "Hello, World!";
             }
@@ -343,7 +343,7 @@ mod tests {
     #[test]
     fn binary_operations() {
         let result = compile(indoc! {"
-            def main() {
+            def main {
                 var x = 5;
                 x += 1;
                 x -= 1;
@@ -364,7 +364,7 @@ mod tests {
     #[test]
     fn conditional_branches() {
         let result = compile(indoc! {"
-            def main() {
+            def main {
                 if !false {
                     if false {} else {}
                 } else if true {}
@@ -381,7 +381,7 @@ mod tests {
     #[test]
     fn while_loop() {
         let result = compile(indoc! {"
-            def main() {
+            def main {
                 while true {
                     var i = 0;
                     break;
@@ -399,7 +399,7 @@ mod tests {
     #[test]
     fn each_loop() {
         let result = compile(indoc! {"
-            def main() {
+            def main {
                 var arr = [int 1, 2, 3];
                 each n in arr {
                     var i = n * 2;
@@ -417,7 +417,7 @@ mod tests {
     #[test]
     fn index_access() {
         let result = compile(indoc! {"
-            def main() {
+            def main {
                 var arr = [int 1, 2, 3];
                 arr[0];
             }
@@ -433,11 +433,11 @@ mod tests {
     #[test]
     fn function_call() {
         let result = compile(indoc! {"
-            def foo(): int {
+            def foo: int {
                 return 5;
             }
 
-            def main() {
+            def main {
                 var x = foo();
             }
         "});
@@ -452,7 +452,7 @@ mod tests {
     #[test]
     fn print_value() {
         let result = compile(indoc! {r#"
-            def main() {
+            def main {
                 debug "Hello, World!";
             }
         "#});

--- a/kabac/src/lexer/token.rs
+++ b/kabac/src/lexer/token.rs
@@ -49,7 +49,7 @@ pub enum TokenKind {
     #[token("break")]    Break,
     #[token("continue")] Continue,
     #[token("in")]       In,
-    #[token("fn")]       Fn,
+    #[token("def")]      Def,
     #[token("return")]   Return,
     #[token("debug")]    Debug,
 
@@ -126,7 +126,7 @@ impl Display for TokenKind {
             Self::Break => write!(f, "`break` keyword"),
             Self::Continue => write!(f, "`continue` keyword"),
             Self::In => write!(f, "`in` keyword"),
-            Self::Fn => write!(f, "`fn` keyword"),
+            Self::Def => write!(f, "`def` keyword"),
             Self::Return => write!(f, "`return` keyword"),
             Self::Debug => write!(f, "`debug` keyword"),
 

--- a/kabac/src/parser/expression.rs
+++ b/kabac/src/parser/expression.rs
@@ -1,8 +1,7 @@
 use super::{
     error::{ParsingError, ParsingErrorVariant},
     state::ParserState,
-    tn::TypeNotationParser,
-    Result,
+    tn, Result,
 };
 use crate::{
     ast::{AstNode, Literal},
@@ -542,7 +541,7 @@ fn parse_array_literal(state: &ParserState) -> Result<AstNode> {
     state.tokens.skip(&TokenKind::LBrack)?;
 
     // Expecting type notation
-    let elem_tn = TypeNotationParser::new(state).parse()?;
+    let elem_tn = tn::parse(state)?;
 
     // Can have >= 0 elements
     let mut elems = vec![];

--- a/kabac/src/parser/function.rs
+++ b/kabac/src/parser/function.rs
@@ -2,8 +2,7 @@ use super::{
     block,
     error::{ParsingError, ParsingErrorVariant},
     state::ParserState,
-    tn::TypeNotationParser,
-    Result,
+    tn, Result,
 };
 use crate::{
     ast::{AstNode, FunctionParam},
@@ -79,7 +78,7 @@ fn parse_params(state: &ParserState) -> Result<Vec<FunctionParam>> {
         state.tokens.skip(&TokenKind::Colon)?;
 
         // Expecting type notation
-        let tn = TypeNotationParser::new(state).parse()?;
+        let tn = tn::parse(state)?;
 
         params.push(FunctionParam { sym, sym_id, tn });
 
@@ -115,7 +114,7 @@ fn parse_return_tn(state: &ParserState) -> Result<Option<AstNode>> {
 
     state.tokens.skip(&TokenKind::Colon)?;
 
-    Ok(Some(TypeNotationParser::new(state).parse()?))
+    Ok(Some(tn::parse(state)?))
 }
 
 #[cfg(test)]

--- a/kabac/src/parser/function.rs
+++ b/kabac/src/parser/function.rs
@@ -13,7 +13,7 @@ pub fn parse(state: &ParserState) -> Result<AstNode> {
     let start = state.tokens.current().span.start;
 
     // Expecting "fn" keyword
-    state.tokens.skip(&TokenKind::Fn)?;
+    state.tokens.skip(&TokenKind::Def)?;
 
     // Expecting symbol
     let sym_id = state.next_symbol_id();
@@ -127,18 +127,18 @@ mod tests {
     #[test]
     fn empty_function_definition() {
         assert_ast(
-            "fn foo() {}",
+            "def foo() {}",
             AstNode::FunctionDefinition {
                 sym: Box::new(AstNode::Symbol {
                     name: String::from("foo"),
-                    span: 3..6,
+                    span: 4..7,
                 }),
                 sym_id: 1,
                 params: vec![],
                 return_tn: None,
                 body: vec![],
                 scope_id: 2,
-                span: 0..11,
+                span: 0..12,
             },
         );
     }
@@ -146,41 +146,41 @@ mod tests {
     #[test]
     fn function_definition_with_parameters_and_trailing_comma() {
         assert_ast(
-            "fn foo(x: int, y: bool,) {}",
+            "def foo(x: int, y: bool,) {}",
             AstNode::FunctionDefinition {
                 sym: Box::new(AstNode::Symbol {
                     name: String::from("foo"),
-                    span: 3..6,
+                    span: 4..7,
                 }),
                 sym_id: 1,
                 params: vec![
                     FunctionParam {
                         sym: AstNode::Symbol {
                             name: String::from("x"),
-                            span: 7..8,
+                            span: 8..9,
                         },
                         sym_id: 2,
                         tn: AstNode::TypeNotation {
                             tn: TypeNotation::Symbol(String::from("int")),
-                            span: 10..13,
+                            span: 11..14,
                         },
                     },
                     FunctionParam {
                         sym: AstNode::Symbol {
                             name: String::from("y"),
-                            span: 15..16,
+                            span: 16..17,
                         },
                         sym_id: 3,
                         tn: AstNode::TypeNotation {
                             tn: TypeNotation::Symbol(String::from("bool")),
-                            span: 18..22,
+                            span: 19..23,
                         },
                     },
                 ],
                 return_tn: None,
                 body: vec![],
                 scope_id: 2,
-                span: 0..27,
+                span: 0..28,
             },
         );
     }
@@ -188,38 +188,38 @@ mod tests {
     #[test]
     fn function_definition_with_parameter_and_body() {
         assert_ast(
-            "fn write(x: int) { print(x); }",
+            "def write(x: int) { print(x); }",
             AstNode::FunctionDefinition {
                 sym: Box::new(AstNode::Symbol {
                     name: String::from("write"),
-                    span: 3..8,
+                    span: 4..9,
                 }),
                 sym_id: 1,
                 params: vec![FunctionParam {
                     sym: AstNode::Symbol {
                         name: String::from("x"),
-                        span: 9..10,
+                        span: 10..11,
                     },
                     sym_id: 2,
                     tn: AstNode::TypeNotation {
                         tn: TypeNotation::Symbol(String::from("int")),
-                        span: 12..15,
+                        span: 13..16,
                     },
                 }],
                 return_tn: None,
                 body: vec![AstNode::FunctionCall {
                     callee: Box::new(AstNode::Symbol {
                         name: String::from("print"),
-                        span: 19..24,
+                        span: 20..25,
                     }),
                     args: vec![AstNode::Symbol {
                         name: String::from("x"),
-                        span: 25..26,
+                        span: 26..27,
                     }],
-                    span: 19..27,
+                    span: 20..28,
                 }],
                 scope_id: 2,
-                span: 0..30,
+                span: 0..31,
             },
         );
     }
@@ -227,27 +227,27 @@ mod tests {
     #[test]
     fn function_definition_with_return_statement() {
         assert_ast(
-            "fn foo(): int { return 5; }",
+            "def foo(): int { return 5; }",
             AstNode::FunctionDefinition {
                 sym: Box::new(AstNode::Symbol {
                     name: String::from("foo"),
-                    span: 3..6,
+                    span: 4..7,
                 }),
                 sym_id: 1,
                 params: vec![],
                 return_tn: Some(Box::new(AstNode::TypeNotation {
                     tn: TypeNotation::Symbol(String::from("int")),
-                    span: 10..13,
+                    span: 11..14,
                 })),
                 body: vec![AstNode::Return {
                     expr: Some(Box::new(AstNode::Literal {
                         lit: Literal::Int(5),
-                        span: 23..24,
+                        span: 24..25,
                     })),
-                    span: 16..24,
+                    span: 17..25,
                 }],
                 scope_id: 2,
-                span: 0..27,
+                span: 0..28,
             },
         );
     }

--- a/kabac/src/parser/statement.rs
+++ b/kabac/src/parser/statement.rs
@@ -14,7 +14,7 @@ pub fn parse(state: &ParserState) -> Result<AstNode> {
         TokenKind::While => return while_loop::parse(state),
         TokenKind::Each => return each_loop::parse(state),
         TokenKind::Break | TokenKind::Continue => return parse_loop_control(state),
-        TokenKind::Fn => return function::parse(state),
+        TokenKind::Def => return function::parse(state),
         TokenKind::Return => return parse_return_statement(state),
         TokenKind::Debug => return parse_debug_statement(state),
         _ => (),

--- a/kabac/src/parser/variable.rs
+++ b/kabac/src/parser/variable.rs
@@ -2,7 +2,7 @@ use super::{
     error::{ParsingError, ParsingErrorVariant, Result},
     expression,
     state::ParserState,
-    tn::TypeNotationParser,
+    tn,
 };
 use crate::{ast::AstNode, lexer::token::TokenKind};
 
@@ -64,7 +64,7 @@ fn parse_sym(state: &ParserState) -> Result<AstNode> {
 fn parse_tn(state: &ParserState) -> Result<Option<AstNode>> {
     let tn = if state.tokens.current_is(&TokenKind::Colon) {
         state.tokens.skip(&TokenKind::Colon)?;
-        Some(TypeNotationParser::new(state).parse()?)
+        Some(tn::parse(state)?)
     } else {
         None
     };

--- a/kabac/src/semantic/assignment.rs
+++ b/kabac/src/semantic/assignment.rs
@@ -135,7 +135,7 @@ mod tests {
     #[test]
     fn assigning_variables() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     var x = 0;
                     x = 10;
 
@@ -151,7 +151,7 @@ mod tests {
     #[test]
     fn assigning_variable_using_shorthand_forms() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     var i = 0;
                     i += 1;
                     i -= 2;
@@ -165,7 +165,7 @@ mod tests {
     #[test]
     fn mod_assign_with_float_value() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     var i = 5.0;
                     i %= 2.5;
                 }
@@ -175,7 +175,7 @@ mod tests {
     #[test]
     fn assigning_value_with_non_existing_variable() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     var x: float = 5.0;
                     x = y;
                 }
@@ -185,7 +185,7 @@ mod tests {
     #[test]
     fn assigning_overflowed_value() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     var x: sbyte = 0;
                     x = 128;
                 }
@@ -195,7 +195,7 @@ mod tests {
     #[test]
     fn using_math_expression_as_lhs_in_assignment() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     1 + 1 = 5;
                 }
             "})
@@ -204,7 +204,7 @@ mod tests {
     #[test]
     fn using_boolean_expression_as_lhs_in_assignment() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     true || false = false;
                 }
             "})
@@ -213,7 +213,7 @@ mod tests {
     #[test]
     fn using_integer_grouped_expression_as_lhs_in_assignment() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     (50) = true;
                 }
             "})
@@ -222,7 +222,7 @@ mod tests {
     #[test]
     fn using_boolean_type_in_shorthand_assignment() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     true += true;
                 }
             "})
@@ -235,7 +235,7 @@ mod tests {
     #[test]
     fn assign_to_array_element() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     var arr = [bool true, false, true];
 
                     arr[1] = true;
@@ -246,7 +246,7 @@ mod tests {
     #[test]
     fn shorthand_assign_to_array_element() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     var arr = [float 0.5, 1.1, 2.3];
 
                     arr[0] += 5.5;

--- a/kabac/src/semantic/assignment.rs
+++ b/kabac/src/semantic/assignment.rs
@@ -135,7 +135,7 @@ mod tests {
     #[test]
     fn assigning_variables() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     var x = 0;
                     x = 10;
 
@@ -151,7 +151,7 @@ mod tests {
     #[test]
     fn assigning_variable_using_shorthand_forms() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     var i = 0;
                     i += 1;
                     i -= 2;
@@ -165,7 +165,7 @@ mod tests {
     #[test]
     fn mod_assign_with_float_value() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     var i = 5.0;
                     i %= 2.5;
                 }
@@ -175,7 +175,7 @@ mod tests {
     #[test]
     fn assigning_value_with_non_existing_variable() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     var x: float = 5.0;
                     x = y;
                 }
@@ -185,7 +185,7 @@ mod tests {
     #[test]
     fn assigning_overflowed_value() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     var x: sbyte = 0;
                     x = 128;
                 }
@@ -195,7 +195,7 @@ mod tests {
     #[test]
     fn using_math_expression_as_lhs_in_assignment() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     1 + 1 = 5;
                 }
             "})
@@ -204,7 +204,7 @@ mod tests {
     #[test]
     fn using_boolean_expression_as_lhs_in_assignment() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     true || false = false;
                 }
             "})
@@ -213,7 +213,7 @@ mod tests {
     #[test]
     fn using_integer_grouped_expression_as_lhs_in_assignment() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     (50) = true;
                 }
             "})
@@ -222,7 +222,7 @@ mod tests {
     #[test]
     fn using_boolean_type_in_shorthand_assignment() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     true += true;
                 }
             "})
@@ -235,7 +235,7 @@ mod tests {
     #[test]
     fn assign_to_array_element() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     var arr = [bool true, false, true];
 
                     arr[1] = true;
@@ -246,7 +246,7 @@ mod tests {
     #[test]
     fn shorthand_assign_to_array_element() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     var arr = [float 0.5, 1.1, 2.3];
 
                     arr[0] += 5.5;

--- a/kabac/src/semantic/conditional.rs
+++ b/kabac/src/semantic/conditional.rs
@@ -165,7 +165,7 @@ mod tests {
     #[test]
     fn if_else_statements() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     var condition1 = 5 < 10;
                     var condition2 = 0.5 < 0.75;
 
@@ -185,7 +185,7 @@ mod tests {
     #[test]
     fn nested_if_statements() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     if 1 + 1 == 2 {
                         if 2 + 2 == 4 {
                             if 3 + 3 == 6 {
@@ -200,7 +200,7 @@ mod tests {
     #[test]
     fn using_variable_declared_inside_conditional_scope_from_outside() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     if true {
                         var x = 50;
                         debug x;
@@ -214,7 +214,7 @@ mod tests {
     #[test]
     fn using_math_expression_as_condition_in_if_statement() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     if 1 + 1 {
                         debug 1;
                     }
@@ -225,7 +225,7 @@ mod tests {
     #[test]
     fn using_variable_declared_in_sibling_branch_scope() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     if true {
                         var x = 50;
                     } else {

--- a/kabac/src/semantic/conditional.rs
+++ b/kabac/src/semantic/conditional.rs
@@ -165,7 +165,7 @@ mod tests {
     #[test]
     fn if_else_statements() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     var condition1 = 5 < 10;
                     var condition2 = 0.5 < 0.75;
 
@@ -185,7 +185,7 @@ mod tests {
     #[test]
     fn nested_if_statements() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     if 1 + 1 == 2 {
                         if 2 + 2 == 4 {
                             if 3 + 3 == 6 {
@@ -200,7 +200,7 @@ mod tests {
     #[test]
     fn using_variable_declared_inside_conditional_scope_from_outside() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     if true {
                         var x = 50;
                         debug x;
@@ -214,7 +214,7 @@ mod tests {
     #[test]
     fn using_math_expression_as_condition_in_if_statement() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     if 1 + 1 {
                         debug 1;
                     }
@@ -225,7 +225,7 @@ mod tests {
     #[test]
     fn using_variable_declared_in_sibling_branch_scope() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     if true {
                         var x = 50;
                     } else {

--- a/kabac/src/semantic/each_loop.rs
+++ b/kabac/src/semantic/each_loop.rs
@@ -118,7 +118,7 @@ mod tests {
     #[test]
     fn each_loop_statements() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     each n in [int 1, 2, 3] {
                         debug n;
                     }
@@ -134,7 +134,7 @@ mod tests {
     #[test]
     fn each_loop_statement_with_non_array_expression() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     each n in true {
                         debug n;
                     }
@@ -145,7 +145,7 @@ mod tests {
     #[test]
     fn accessing_elem_id_outside_scope() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     each n in [int 1, 2] {}
 
                     debug n;

--- a/kabac/src/semantic/each_loop.rs
+++ b/kabac/src/semantic/each_loop.rs
@@ -118,7 +118,7 @@ mod tests {
     #[test]
     fn each_loop_statements() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     each n in [int 1, 2, 3] {
                         debug n;
                     }
@@ -134,7 +134,7 @@ mod tests {
     #[test]
     fn each_loop_statement_with_non_array_expression() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     each n in true {
                         debug n;
                     }
@@ -145,7 +145,7 @@ mod tests {
     #[test]
     fn accessing_elem_id_outside_scope() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     each n in [int 1, 2] {}
 
                     debug n;

--- a/kabac/src/semantic/function.rs
+++ b/kabac/src/semantic/function.rs
@@ -233,18 +233,18 @@ mod tests {
     #[test]
     fn defining_function_without_parameter_or_return_type() {
         assert_is_ok(indoc! {"
-                fn add() {}
+                def add() {}
             "});
     }
 
     #[test]
     fn defining_duplicated_functions() {
         assert_is_err(indoc! {"
-                fn print_sum_of(a: int, b: int) {
+                def print_sum_of(a: int, b: int) {
                     debug a + b;
                 }
 
-                fn print_sum_of(a: float, b: float) {
+                def print_sum_of(a: float, b: float) {
                     debug a + b;
                 }
             "});
@@ -253,7 +253,7 @@ mod tests {
     #[test]
     fn defining_functions_both_with_parameters_and_return_type() {
         assert_is_ok(indoc! {"
-                fn sum(x: int, y: int): int {
+                def sum(x: int, y: int): int {
                     return x + y;
                 }
             "});
@@ -262,7 +262,7 @@ mod tests {
     #[test]
     fn recursive_fibonacci_function() {
         assert_is_ok(indoc! {"
-                fn fibonacci(n: int): int {
+                def fibonacci(n: int): int {
                     if n == 0 {
                         return 0;
                     } else if n == 1 || n == 2 {
@@ -276,7 +276,7 @@ mod tests {
     #[test]
     fn recursive_functions_with_void_return_type() {
         assert_is_ok(indoc! {"
-                fn count_to_zero(n: int) {
+                def count_to_zero(n: int) {
                     debug n;
                     if n == 0 {
                         return;
@@ -284,7 +284,7 @@ mod tests {
                     count_to_zero(n-1);
                 }
 
-                fn main() {
+                def main() {
                     count_to_zero(10);
                 }
             "});
@@ -293,11 +293,11 @@ mod tests {
     #[test]
     fn returning_from_functions_with_conditional_and_loop_statements() {
         assert_is_ok(indoc! {"
-                fn first(): int {
+                def first(): int {
                     return 5;
                 }
 
-                fn second(): int {
+                def second(): int {
                     if false {
                         return 0;
                     } else {
@@ -305,21 +305,21 @@ mod tests {
                     }
                 }
 
-                fn third(): int {
+                def third(): int {
                     if false {
                         return 0;
                     }
                     return 1;
                 }
 
-                fn fourth(): int {
+                def fourth(): int {
                     while false {
                         return 0;
                     }
                     return 1;
                 }
 
-                fn fifth(): int {
+                def fifth(): int {
                     return 1;
 
                     if false {
@@ -332,15 +332,15 @@ mod tests {
     #[test]
     fn defining_functions_not_in_order() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     call_foo();
                 }
 
-                fn call_foo() {
+                def call_foo() {
                     call_bar();
                 }
 
-                fn call_bar() {
+                def call_bar() {
                     debug true;
                 }
             "})
@@ -349,11 +349,11 @@ mod tests {
     #[test]
     fn prevent_incompatible_int_type_on_function_return_value() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     var x: int = foo();
                 }
 
-                fn foo(): sbyte {
+                def foo(): sbyte {
                     return 5;
                 }
             "});
@@ -362,11 +362,11 @@ mod tests {
     #[test]
     fn prevent_calling_function_with_missing_args() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     foo();
                 }
 
-                fn foo(x: sbyte): sbyte {
+                def foo(x: sbyte): sbyte {
                     return x;
                 }
             "});
@@ -375,11 +375,11 @@ mod tests {
     #[test]
     fn prevent_calling_function_with_too_many_args() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     foo(5, 7);
                 }
 
-                fn foo(x: sbyte): sbyte {
+                def foo(x: sbyte): sbyte {
                     return x;
                 }
             "});
@@ -388,13 +388,13 @@ mod tests {
     #[test]
     fn aliasing_function_identifier() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     var aliased = return_two;
 
                     debug aliased();
                 }
 
-                fn return_two(): int {
+                def return_two(): int {
                     return 2;
                 }
             "});
@@ -403,15 +403,15 @@ mod tests {
     #[test]
     fn using_function_type_as_function_parameter() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     debug get_num(produce);
                 }
 
-                fn get_num(producer: () -> int): int {
+                def get_num(producer: () -> int): int {
                     return producer() + 5;
                 }
 
-                fn produce(): int {
+                def produce(): int {
                     return 10;
                 }
             "});
@@ -420,15 +420,15 @@ mod tests {
     #[test]
     fn calling_function_returned_by_another_function_call() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     debug foo()();
                 }
 
-                fn foo(): () -> int {
+                def foo(): () -> int {
                     return bar;
                 }
 
-                fn bar(): int {
+                def bar(): int {
                     return 25;
                 }
             "});
@@ -437,19 +437,18 @@ mod tests {
     #[test]
     fn calling_function_with_array_parameter() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     foo([int 1, 2, 3]);
                 }
 
-                fn foo(arr: []int) {
-                }
+                def foo(arr: []int) {}
             "});
     }
 
     #[test]
     fn calling_function_with_array_parameter_using_different_array_sizes() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     foo([int 1, 2, 3]);
 
                     foo([int]);
@@ -457,22 +456,21 @@ mod tests {
                     foo([int 1]);
                 }
 
-                fn foo(arr: []int) {
-                }
+                def foo(arr: []int) {}
             "});
     }
 
     #[test]
     fn returning_array_from_a_function() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     var arr_1: []int = foo();
                     var arr_2: []int = foo();
 
                     arr_1[0] = 10;
                 }
 
-                fn foo(): []int {
+                def foo(): []int {
                     return [int 1, 2, 3];
                 }
             "});
@@ -481,9 +479,9 @@ mod tests {
     #[test]
     fn defining_function_not_in_global_scope() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     if true {
-                        fn foo() {}
+                        def foo() {}
                     }
                 }
             "});
@@ -492,35 +490,35 @@ mod tests {
     #[test]
     fn defining_function_with_a_non_existing_return_type() {
         assert_is_err(indoc! {"
-                fn foo(): NonExistingType { }
+                def foo(): NonExistingType { }
             "});
     }
 
     #[test]
     fn defining_function_with_duplicated_parameter_name() {
         assert_is_err(indoc! {"
-                fn add_sum_of(x: int, x: int) { }
+                def add_sum_of(x: int, x: int) { }
             "});
     }
 
     #[test]
     fn defining_function_with_a_non_existing_parameter_type() {
         assert_is_err(indoc! {"
-                fn foo(x: NonExistingType) { }
+                def foo(x: NonExistingType) { }
             "});
     }
 
     #[test]
     fn defining_function_with_void_parameter_type() {
         assert_is_err(indoc! {"
-                fn foo(x: Void) { }
+                def foo(x: Void) { }
             "});
     }
 
     #[test]
     fn returning_value_from_function_with_void_return_type() {
         assert_is_err(indoc! {"
-                fn foo() {
+                def foo() {
                     return 5;
                 }
             "});
@@ -529,7 +527,7 @@ mod tests {
     #[test]
     fn returning_value_from_function_with_mismatched_return_type() {
         assert_is_err(indoc! {"
-                fn sum(x: int, y: int): int {
+                def sum(x: int, y: int): int {
                     return 5.0;
                 }
             "});
@@ -538,7 +536,7 @@ mod tests {
     #[test]
     fn invalid_statement_after_return() {
         assert_is_err(indoc! {"
-                fn get_five(): int {
+                def get_five(): int {
                     return 5;
                     1 + true; // should be error
                 }
@@ -548,7 +546,7 @@ mod tests {
     #[test]
     fn returning_non_existing_variable() {
         assert_is_err(indoc! {"
-                fn foo(): int {
+                def foo(): int {
                     return not_exist;
                 }
             "});
@@ -557,7 +555,7 @@ mod tests {
     #[test]
     fn defining_function_with_missing_return_in_other_branches() {
         assert_is_err(indoc! {"
-                fn foo(): int {
+                def foo(): int {
                     if false {
                         return 5;
                     }
@@ -568,7 +566,7 @@ mod tests {
     #[test]
     fn defining_function_with_missing_return_in_else_branch_or_outer_scope() {
         assert_is_err(indoc! {"
-                fn foo(): int {
+                def foo(): int {
                     if false {
                         return 0;
                     } else if !true {
@@ -581,7 +579,7 @@ mod tests {
     #[test]
     fn defining_function_with_missing_return_in_outer_scope_of_while_statement() {
         assert_is_err(indoc! {"
-                fn foo(): int {
+                def foo(): int {
                     while false {
                         return 0;
                     }

--- a/kabac/src/semantic/function.rs
+++ b/kabac/src/semantic/function.rs
@@ -233,7 +233,7 @@ mod tests {
     #[test]
     fn defining_function_without_parameter_or_return_type() {
         assert_is_ok(indoc! {"
-                def add() {}
+                def add {}
             "});
     }
 
@@ -284,7 +284,7 @@ mod tests {
                     count_to_zero(n-1);
                 }
 
-                def main() {
+                def main {
                     count_to_zero(10);
                 }
             "});
@@ -293,11 +293,11 @@ mod tests {
     #[test]
     fn returning_from_functions_with_conditional_and_loop_statements() {
         assert_is_ok(indoc! {"
-                def first(): int {
+                def first: int {
                     return 5;
                 }
 
-                def second(): int {
+                def second: int {
                     if false {
                         return 0;
                     } else {
@@ -305,21 +305,21 @@ mod tests {
                     }
                 }
 
-                def third(): int {
+                def third: int {
                     if false {
                         return 0;
                     }
                     return 1;
                 }
 
-                def fourth(): int {
+                def fourth: int {
                     while false {
                         return 0;
                     }
                     return 1;
                 }
 
-                def fifth(): int {
+                def fifth: int {
                     return 1;
 
                     if false {
@@ -332,15 +332,15 @@ mod tests {
     #[test]
     fn defining_functions_not_in_order() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     call_foo();
                 }
 
-                def call_foo() {
+                def call_foo {
                     call_bar();
                 }
 
-                def call_bar() {
+                def call_bar {
                     debug true;
                 }
             "})
@@ -349,11 +349,11 @@ mod tests {
     #[test]
     fn prevent_incompatible_int_type_on_function_return_value() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     var x: int = foo();
                 }
 
-                def foo(): sbyte {
+                def foo: sbyte {
                     return 5;
                 }
             "});
@@ -362,7 +362,7 @@ mod tests {
     #[test]
     fn prevent_calling_function_with_missing_args() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     foo();
                 }
 
@@ -375,7 +375,7 @@ mod tests {
     #[test]
     fn prevent_calling_function_with_too_many_args() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     foo(5, 7);
                 }
 
@@ -388,13 +388,13 @@ mod tests {
     #[test]
     fn aliasing_function_identifier() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     var aliased = return_two;
 
                     debug aliased();
                 }
 
-                def return_two(): int {
+                def return_two: int {
                     return 2;
                 }
             "});
@@ -403,7 +403,7 @@ mod tests {
     #[test]
     fn using_function_type_as_function_parameter() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     debug get_num(produce);
                 }
 
@@ -411,7 +411,7 @@ mod tests {
                     return producer() + 5;
                 }
 
-                def produce(): int {
+                def produce: int {
                     return 10;
                 }
             "});
@@ -420,15 +420,15 @@ mod tests {
     #[test]
     fn calling_function_returned_by_another_function_call() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     debug foo()();
                 }
 
-                def foo(): () -> int {
+                def foo: () -> int {
                     return bar;
                 }
 
-                def bar(): int {
+                def bar: int {
                     return 25;
                 }
             "});
@@ -437,7 +437,7 @@ mod tests {
     #[test]
     fn calling_function_with_array_parameter() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     foo([int 1, 2, 3]);
                 }
 
@@ -448,7 +448,7 @@ mod tests {
     #[test]
     fn calling_function_with_array_parameter_using_different_array_sizes() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     foo([int 1, 2, 3]);
 
                     foo([int]);
@@ -463,14 +463,14 @@ mod tests {
     #[test]
     fn returning_array_from_a_function() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     var arr_1: []int = foo();
                     var arr_2: []int = foo();
 
                     arr_1[0] = 10;
                 }
 
-                def foo(): []int {
+                def foo: []int {
                     return [int 1, 2, 3];
                 }
             "});
@@ -479,9 +479,9 @@ mod tests {
     #[test]
     fn defining_function_not_in_global_scope() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     if true {
-                        def foo() {}
+                        def foo {}
                     }
                 }
             "});
@@ -490,7 +490,7 @@ mod tests {
     #[test]
     fn defining_function_with_a_non_existing_return_type() {
         assert_is_err(indoc! {"
-                def foo(): NonExistingType { }
+                def foo: NonExistingType { }
             "});
     }
 
@@ -518,7 +518,7 @@ mod tests {
     #[test]
     fn returning_value_from_function_with_void_return_type() {
         assert_is_err(indoc! {"
-                def foo() {
+                def foo {
                     return 5;
                 }
             "});
@@ -536,7 +536,7 @@ mod tests {
     #[test]
     fn invalid_statement_after_return() {
         assert_is_err(indoc! {"
-                def get_five(): int {
+                def get_five: int {
                     return 5;
                     1 + true; // should be error
                 }
@@ -546,7 +546,7 @@ mod tests {
     #[test]
     fn returning_non_existing_variable() {
         assert_is_err(indoc! {"
-                def foo(): int {
+                def foo: int {
                     return not_exist;
                 }
             "});
@@ -555,7 +555,7 @@ mod tests {
     #[test]
     fn defining_function_with_missing_return_in_other_branches() {
         assert_is_err(indoc! {"
-                def foo(): int {
+                def foo: int {
                     if false {
                         return 5;
                     }
@@ -566,7 +566,7 @@ mod tests {
     #[test]
     fn defining_function_with_missing_return_in_else_branch_or_outer_scope() {
         assert_is_err(indoc! {"
-                def foo(): int {
+                def foo: int {
                     if false {
                         return 0;
                     } else if !true {
@@ -579,7 +579,7 @@ mod tests {
     #[test]
     fn defining_function_with_missing_return_in_outer_scope_of_while_statement() {
         assert_is_err(indoc! {"
-                def foo(): int {
+                def foo: int {
                     while false {
                         return 0;
                     }

--- a/kabac/src/semantic/statement.rs
+++ b/kabac/src/semantic/statement.rs
@@ -112,7 +112,7 @@ mod tests {
     #[test]
     fn debug_expression() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     debug 17 * 5;
                 }
             "});
@@ -121,11 +121,11 @@ mod tests {
     #[test]
     fn debug_expression_with_void_type() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     debug this_is_void();
                 }
 
-                fn this_is_void() {
+                def this_is_void() {
                 }
             "});
     }

--- a/kabac/src/semantic/statement.rs
+++ b/kabac/src/semantic/statement.rs
@@ -112,7 +112,7 @@ mod tests {
     #[test]
     fn debug_expression() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     debug 17 * 5;
                 }
             "});
@@ -121,12 +121,11 @@ mod tests {
     #[test]
     fn debug_expression_with_void_type() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     debug this_is_void();
                 }
 
-                def this_is_void() {
-                }
+                def this_is_void {}
             "});
     }
 }

--- a/kabac/src/semantic/variable.rs
+++ b/kabac/src/semantic/variable.rs
@@ -135,7 +135,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_type_annotation_and_initial_value() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     var x: int = 5;
                 }
             "});
@@ -144,7 +144,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_type_inferring() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     var x = 5;
                 }
             "});
@@ -153,7 +153,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_builtin_type_symbol() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     var int = 5;
                 }
             "});
@@ -162,7 +162,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_float_literal() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     var x: float = -0.5;
                     var y: double = 9.99;
                 }
@@ -172,7 +172,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_different_int_types() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     var a: sbyte = 10;
                     var b: int = a;
                 }
@@ -182,7 +182,7 @@ mod tests {
     #[test]
     fn declaring_sbyte_variable_with_overflow_constant() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     var a: sbyte = 127 + 1;
                 }
             "});
@@ -191,7 +191,7 @@ mod tests {
     #[test]
     fn declaring_short_variable_with_overflow_constant() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     var a: short = -32768 - 1;
                 }
             "});
@@ -200,7 +200,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_bool_literal() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     var x = true;
                 }
             "});
@@ -209,7 +209,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_char_literal() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     var x = 'a';
                     var y: char = 'b';
                 }
@@ -219,7 +219,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_string_literal() {
         assert_is_ok(indoc! {r#"
-                fn main() {
+                def main() {
                     var x = "abc def \n 123\t";
                     var y: string = "hello, world!";
                 }
@@ -229,7 +229,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_void_type() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     var x: Void = 5;
                 }
             "});
@@ -238,7 +238,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_incompatible_type() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     var x: int = 5.0;
                 }
             "})
@@ -247,7 +247,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_non_existing_type() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     var x: NonExistingType = 10;
                 }
             "})
@@ -256,7 +256,7 @@ mod tests {
     #[test]
     fn redeclaring_variable_in_the_same_scope() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     var x = 5;
                     var x = 10;
                 }
@@ -270,13 +270,13 @@ mod tests {
     #[test]
     fn declaring_variable_with_function_pointer_as_value() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     var x: () -> int = produce;
 
                     debug x();
                 }
 
-                fn produce(): int {
+                def produce(): int {
                     return 5;
                 }
             "});
@@ -285,18 +285,18 @@ mod tests {
     #[test]
     fn declaring_callable_type_variable_with_non_existing_param_type() {
         assert_is_err(indoc! {"
-                fn main() {}
+                def main() {}
 
-                fn produce(f: (NotExist) -> Void) {}
+                def produce(f: (NotExist) -> Void) {}
             "});
     }
 
     #[test]
     fn declaring_callable_type_variable_with_non_existing_return_type() {
         assert_is_err(indoc! {"
-                fn main() {}
+                def main() {}
 
-                fn produce(f: () -> NotExist) {}
+                def produce(f: () -> NotExist) {}
             "});
     }
 
@@ -307,7 +307,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_array_literal() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     var arr = [int 1];
                 }
             "});
@@ -316,7 +316,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_empty_array_literal() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     var arr = [int];
                 }
             "});
@@ -325,7 +325,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_array_type_notation() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     var arr: []int = [int 5, 9, 10];
                 }
             "});
@@ -334,7 +334,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_empty_array_literal_and_type_notation() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     var arr: []int = [int];
                 }
             "});
@@ -343,7 +343,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_incompatible_array_literal() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     var arr: []int = [short 5];
                 }
             "});
@@ -352,7 +352,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_nested_arrays_and_type_notation() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     var arr: [][]int = [[]int [int 5, 9, 10], [int 1, 2, 3]];
                 }
             "});
@@ -361,7 +361,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_nested_empty_arrays_and_type_notation() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     var arr: [][][]int = [[][]int [[]int], [[]int]];
                 }
             "});
@@ -370,7 +370,7 @@ mod tests {
     #[test]
     fn declaring_variables_of_sbyte_array() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     var arr: []sbyte = [sbyte];
 
                     var arr2: []sbyte = [sbyte 1, 2, 3];
@@ -381,7 +381,7 @@ mod tests {
     #[test]
     fn declaring_variables_of_long_array_with_math_expr_in_literal() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     var x: long = 10;
                     var arr: []long = [long 1, 2, 3 + x];
                 }
@@ -391,15 +391,15 @@ mod tests {
     #[test]
     fn declaring_variable_with_array_literal_of_function_types() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     var arr = [()->int five, six];
                 }
 
-                fn five(): int {
+                def five(): int {
                     return 5;
                 }
 
-                fn six(): int {
+                def six(): int {
                     return 6;
                 }
             "});
@@ -408,7 +408,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_incompatible_element_types() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     var arr = [int 1, 0.5];
                 }
             "});
@@ -417,7 +417,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_non_existing_array_type() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     var arr = [NotExist];
                 }
             "})

--- a/kabac/src/semantic/variable.rs
+++ b/kabac/src/semantic/variable.rs
@@ -135,7 +135,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_type_annotation_and_initial_value() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     var x: int = 5;
                 }
             "});
@@ -144,7 +144,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_type_inferring() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     var x = 5;
                 }
             "});
@@ -153,7 +153,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_builtin_type_symbol() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     var int = 5;
                 }
             "});
@@ -162,7 +162,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_float_literal() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     var x: float = -0.5;
                     var y: double = 9.99;
                 }
@@ -172,7 +172,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_different_int_types() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     var a: sbyte = 10;
                     var b: int = a;
                 }
@@ -182,7 +182,7 @@ mod tests {
     #[test]
     fn declaring_sbyte_variable_with_overflow_constant() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     var a: sbyte = 127 + 1;
                 }
             "});
@@ -191,7 +191,7 @@ mod tests {
     #[test]
     fn declaring_short_variable_with_overflow_constant() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     var a: short = -32768 - 1;
                 }
             "});
@@ -200,7 +200,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_bool_literal() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     var x = true;
                 }
             "});
@@ -209,7 +209,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_char_literal() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     var x = 'a';
                     var y: char = 'b';
                 }
@@ -219,7 +219,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_string_literal() {
         assert_is_ok(indoc! {r#"
-                def main() {
+                def main {
                     var x = "abc def \n 123\t";
                     var y: string = "hello, world!";
                 }
@@ -229,7 +229,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_void_type() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     var x: Void = 5;
                 }
             "});
@@ -238,7 +238,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_incompatible_type() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     var x: int = 5.0;
                 }
             "})
@@ -247,7 +247,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_non_existing_type() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     var x: NonExistingType = 10;
                 }
             "})
@@ -256,7 +256,7 @@ mod tests {
     #[test]
     fn redeclaring_variable_in_the_same_scope() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     var x = 5;
                     var x = 10;
                 }
@@ -270,13 +270,13 @@ mod tests {
     #[test]
     fn declaring_variable_with_function_pointer_as_value() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     var x: () -> int = produce;
 
                     debug x();
                 }
 
-                def produce(): int {
+                def produce: int {
                     return 5;
                 }
             "});
@@ -285,7 +285,7 @@ mod tests {
     #[test]
     fn declaring_callable_type_variable_with_non_existing_param_type() {
         assert_is_err(indoc! {"
-                def main() {}
+                def main {}
 
                 def produce(f: (NotExist) -> Void) {}
             "});
@@ -294,7 +294,7 @@ mod tests {
     #[test]
     fn declaring_callable_type_variable_with_non_existing_return_type() {
         assert_is_err(indoc! {"
-                def main() {}
+                def main {}
 
                 def produce(f: () -> NotExist) {}
             "});
@@ -307,7 +307,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_array_literal() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     var arr = [int 1];
                 }
             "});
@@ -316,7 +316,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_empty_array_literal() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     var arr = [int];
                 }
             "});
@@ -325,7 +325,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_array_type_notation() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     var arr: []int = [int 5, 9, 10];
                 }
             "});
@@ -334,7 +334,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_empty_array_literal_and_type_notation() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     var arr: []int = [int];
                 }
             "});
@@ -343,7 +343,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_incompatible_array_literal() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     var arr: []int = [short 5];
                 }
             "});
@@ -352,7 +352,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_nested_arrays_and_type_notation() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     var arr: [][]int = [[]int [int 5, 9, 10], [int 1, 2, 3]];
                 }
             "});
@@ -361,7 +361,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_nested_empty_arrays_and_type_notation() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     var arr: [][][]int = [[][]int [[]int], [[]int]];
                 }
             "});
@@ -370,7 +370,7 @@ mod tests {
     #[test]
     fn declaring_variables_of_sbyte_array() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     var arr: []sbyte = [sbyte];
 
                     var arr2: []sbyte = [sbyte 1, 2, 3];
@@ -381,7 +381,7 @@ mod tests {
     #[test]
     fn declaring_variables_of_long_array_with_math_expr_in_literal() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     var x: long = 10;
                     var arr: []long = [long 1, 2, 3 + x];
                 }
@@ -391,15 +391,15 @@ mod tests {
     #[test]
     fn declaring_variable_with_array_literal_of_function_types() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     var arr = [()->int five, six];
                 }
 
-                def five(): int {
+                def five: int {
                     return 5;
                 }
 
-                def six(): int {
+                def six: int {
                     return 6;
                 }
             "});
@@ -408,7 +408,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_incompatible_element_types() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     var arr = [int 1, 0.5];
                 }
             "});
@@ -417,7 +417,7 @@ mod tests {
     #[test]
     fn declaring_variable_with_non_existing_array_type() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     var arr = [NotExist];
                 }
             "})

--- a/kabac/src/semantic/while_loop.rs
+++ b/kabac/src/semantic/while_loop.rs
@@ -92,7 +92,7 @@ mod tests {
     #[test]
     fn while_loop_statements() {
         assert_is_ok(indoc! {"
-                fn main() {
+                def main() {
                     while 2 > 5 {
                         debug 1;
                     }
@@ -111,7 +111,7 @@ mod tests {
     #[test]
     fn using_math_expression_as_condition_in_while_statement() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     while 5 + 5 {}
                 }
             "})
@@ -120,7 +120,7 @@ mod tests {
     #[test]
     fn using_break_statement_not_in_loop_scope() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     if true {
                         break;
                     }
@@ -131,7 +131,7 @@ mod tests {
     #[test]
     fn using_invalid_statement_after_loop_control() {
         assert_is_err(indoc! {"
-                fn main() {
+                def main() {
                     while true {
                         break;
                         1 + true; // this should be error

--- a/kabac/src/semantic/while_loop.rs
+++ b/kabac/src/semantic/while_loop.rs
@@ -92,7 +92,7 @@ mod tests {
     #[test]
     fn while_loop_statements() {
         assert_is_ok(indoc! {"
-                def main() {
+                def main {
                     while 2 > 5 {
                         debug 1;
                     }
@@ -111,7 +111,7 @@ mod tests {
     #[test]
     fn using_math_expression_as_condition_in_while_statement() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     while 5 + 5 {}
                 }
             "})
@@ -120,7 +120,7 @@ mod tests {
     #[test]
     fn using_break_statement_not_in_loop_scope() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     if true {
                         break;
                     }
@@ -131,7 +131,7 @@ mod tests {
     #[test]
     fn using_invalid_statement_after_loop_control() {
         assert_is_err(indoc! {"
-                def main() {
+                def main {
                     while true {
                         break;
                         1 + true; // this should be error

--- a/kabart_p/src/runtime.rs
+++ b/kabart_p/src/runtime.rs
@@ -84,7 +84,7 @@ mod tests {
     fn simple_outputting() {
         assert_output_equal(
             indoc! {"
-                def main() {
+                def main {
                     var x = 10;
                     debug x;
                 }
@@ -97,7 +97,7 @@ mod tests {
     fn multiplication_result() {
         assert_output_equal(
             indoc! {"
-                def main() {
+                def main {
                     var x = 5;
                     var y = 10;
 
@@ -112,7 +112,7 @@ mod tests {
     fn overflowing_math() {
         assert_output_equal(
             indoc! {"
-                def main() {
+                def main {
                     debug 2147483647 + 1;
 
                     var a = 2147483647;
@@ -136,7 +136,7 @@ mod tests {
     fn changing_value() {
         assert_output_equal(
             indoc! {"
-                def main() {
+                def main {
                     var x = 2048;
                     debug x;
 
@@ -152,7 +152,7 @@ mod tests {
     fn conditional_branch() {
         assert_output_equal(
             indoc! {"
-                def main() {
+                def main {
                     var x = 2048;
                     if true {
                         var x = 1024;
@@ -169,7 +169,7 @@ mod tests {
     fn multiple_conditional_branches() {
         assert_output_equal(
             indoc! {"
-                def main() {
+                def main {
                     var x = 2048;
                     if false {
                         x = 1024;
@@ -189,7 +189,7 @@ mod tests {
     fn simple_loop() {
         assert_output_equal(
             indoc! {"
-                def main() {
+                def main {
                     var x = 0;
                     while true {
                         debug x;
@@ -208,7 +208,7 @@ mod tests {
     fn boolean_logic_operators() {
         assert_output_equal(
             indoc! {"
-                def main() {
+                def main {
                     if false && true {
                         debug 1;
                     }
@@ -228,7 +228,7 @@ mod tests {
     fn loop_with_conditional_branches() {
         assert_output_equal(
             indoc! {"
-                def main() {
+                def main {
                     var x = 0;
                     while true {
                         x = x + 1;
@@ -249,7 +249,7 @@ mod tests {
     fn shorthand_operators() {
         assert_output_equal(
             indoc! {"
-                def main() {
+                def main {
                     var x = 5;
                     x += 5;
                     debug x;
@@ -271,7 +271,7 @@ mod tests {
     fn function_call() {
         assert_output_equal(
             indoc! {"
-                def main() {
+                def main {
                     debug add_two(5);
                 }
 
@@ -279,7 +279,7 @@ mod tests {
                     return n + get_two();
                 }
 
-                def get_two(): int {
+                def get_two: int {
                     return 2;
                 }
             "},
@@ -291,7 +291,7 @@ mod tests {
     fn calling_function_with_variable_argument() {
         assert_output_equal(
             indoc! {"
-                def main() {
+                def main {
                     var x = 10;
                     dbg(x);
                 }
@@ -308,15 +308,15 @@ mod tests {
     fn doing_math_on_function_call_results() {
         assert_output_equal(
             indoc! {"
-                def main() {
+                def main {
                     debug one() + two();
                 }
 
-                def one(): int {
+                def one: int {
                     return 1;
                 }
 
-                def two(): int {
+                def two: int {
                     return 2;
                 }
             "},
@@ -328,7 +328,7 @@ mod tests {
     fn function_accept_string_parameter_and_return_value() {
         assert_output_equal(
             indoc! {r#"
-                def main() {
+                def main {
                     debug greet("snaztoz");
                 }
 
@@ -346,7 +346,7 @@ mod tests {
     fn recursion() {
         assert_output_equal(
             indoc! {"
-                def main() {
+                def main {
                     debug fibonacci(3);
                 }
 
@@ -365,7 +365,7 @@ mod tests {
     fn recursive_counter() {
         assert_output_equal(
             indoc! {"
-                def main() {
+                def main {
                     count_to_zero(5);
                 }
 
@@ -385,7 +385,7 @@ mod tests {
     fn function_as_argument_to_function_call() {
         assert_output_equal(
             indoc! {"
-                def main() {
+                def main {
                     print(produce);
                 }
 
@@ -397,7 +397,7 @@ mod tests {
                     debug y();
                 }
 
-                def produce(): int {
+                def produce: int {
                     return 5;
                 }
             "},
@@ -409,15 +409,15 @@ mod tests {
     fn calling_function_returned_from_another_function_call() {
         assert_output_equal(
             indoc! {"
-                def main() {
+                def main {
                     debug foo()();
                 }
 
-                def foo(): () -> int {
+                def foo: () -> int {
                     return bar;
                 }
 
-                def bar(): int {
+                def bar: int {
                     return 25;
                 }
             "},
@@ -429,7 +429,7 @@ mod tests {
     fn debug_array() {
         assert_output_equal(
             indoc! {"
-                def main() {
+                def main {
                     debug [[]int [int 1, 2], [int 3, 4]][1][0];
 
                     var arr = [int 1, 3];
@@ -445,7 +445,7 @@ mod tests {
     fn assign_to_array() {
         assert_output_equal(
             indoc! {"
-                def main() {
+                def main {
                     var arr = [int 0, 1, 2];
 
                     arr[0] = 99;
@@ -469,7 +469,7 @@ mod tests {
     fn calling_array_elements() {
         assert_output_equal(
             indoc! {"
-                def main() {
+                def main {
                     var arr = [(int) -> int
                         add_one,
                         add_two,
@@ -503,7 +503,7 @@ mod tests {
     fn returning_array_from_a_function() {
         assert_output_equal(
             indoc! {"
-                def main() {
+                def main {
                     var arr_1 = foo();
                     var arr_2 = foo();
 
@@ -516,7 +516,7 @@ mod tests {
                     debug arr_2[0];
                 }
 
-                def foo(): []int {
+                def foo: []int {
                     return [int 0];
                 }
             "},
@@ -528,7 +528,7 @@ mod tests {
     fn iterate_array_using_each_loop_statement() {
         assert_output_equal(
             indoc! {"
-                def main() {
+                def main {
                     each n in [int 1, 2, 3, 4, 5, 6] {
                         if n == 3 {
                             continue;

--- a/kabart_p/src/runtime.rs
+++ b/kabart_p/src/runtime.rs
@@ -84,7 +84,7 @@ mod tests {
     fn simple_outputting() {
         assert_output_equal(
             indoc! {"
-                fn main() {
+                def main() {
                     var x = 10;
                     debug x;
                 }
@@ -97,7 +97,7 @@ mod tests {
     fn multiplication_result() {
         assert_output_equal(
             indoc! {"
-                fn main() {
+                def main() {
                     var x = 5;
                     var y = 10;
 
@@ -112,7 +112,7 @@ mod tests {
     fn overflowing_math() {
         assert_output_equal(
             indoc! {"
-                fn main() {
+                def main() {
                     debug 2147483647 + 1;
 
                     var a = 2147483647;
@@ -136,7 +136,7 @@ mod tests {
     fn changing_value() {
         assert_output_equal(
             indoc! {"
-                fn main() {
+                def main() {
                     var x = 2048;
                     debug x;
 
@@ -152,7 +152,7 @@ mod tests {
     fn conditional_branch() {
         assert_output_equal(
             indoc! {"
-                fn main() {
+                def main() {
                     var x = 2048;
                     if true {
                         var x = 1024;
@@ -169,7 +169,7 @@ mod tests {
     fn multiple_conditional_branches() {
         assert_output_equal(
             indoc! {"
-                fn main() {
+                def main() {
                     var x = 2048;
                     if false {
                         x = 1024;
@@ -189,7 +189,7 @@ mod tests {
     fn simple_loop() {
         assert_output_equal(
             indoc! {"
-                fn main() {
+                def main() {
                     var x = 0;
                     while true {
                         debug x;
@@ -208,7 +208,7 @@ mod tests {
     fn boolean_logic_operators() {
         assert_output_equal(
             indoc! {"
-                fn main() {
+                def main() {
                     if false && true {
                         debug 1;
                     }
@@ -228,7 +228,7 @@ mod tests {
     fn loop_with_conditional_branches() {
         assert_output_equal(
             indoc! {"
-                fn main() {
+                def main() {
                     var x = 0;
                     while true {
                         x = x + 1;
@@ -249,7 +249,7 @@ mod tests {
     fn shorthand_operators() {
         assert_output_equal(
             indoc! {"
-                fn main() {
+                def main() {
                     var x = 5;
                     x += 5;
                     debug x;
@@ -271,15 +271,15 @@ mod tests {
     fn function_call() {
         assert_output_equal(
             indoc! {"
-                fn main() {
+                def main() {
                     debug add_two(5);
                 }
 
-                fn add_two(n: int): int {
+                def add_two(n: int): int {
                     return n + get_two();
                 }
 
-                fn get_two(): int {
+                def get_two(): int {
                     return 2;
                 }
             "},
@@ -291,12 +291,12 @@ mod tests {
     fn calling_function_with_variable_argument() {
         assert_output_equal(
             indoc! {"
-                fn main() {
+                def main() {
                     var x = 10;
                     dbg(x);
                 }
 
-                fn dbg(n: int) {
+                def dbg(n: int) {
                     debug n;
                 }
             "},
@@ -308,15 +308,15 @@ mod tests {
     fn doing_math_on_function_call_results() {
         assert_output_equal(
             indoc! {"
-                fn main() {
+                def main() {
                     debug one() + two();
                 }
 
-                fn one(): int {
+                def one(): int {
                     return 1;
                 }
 
-                fn two(): int {
+                def two(): int {
                     return 2;
                 }
             "},
@@ -328,11 +328,11 @@ mod tests {
     fn function_accept_string_parameter_and_return_value() {
         assert_output_equal(
             indoc! {r#"
-                fn main() {
+                def main() {
                     debug greet("snaztoz");
                 }
 
-                fn greet(name: string): string {
+                def greet(name: string): string {
                     debug "Hello";
                     debug name;
                     return name;
@@ -346,11 +346,11 @@ mod tests {
     fn recursion() {
         assert_output_equal(
             indoc! {"
-                fn main() {
+                def main() {
                     debug fibonacci(3);
                 }
 
-                fn fibonacci(n: int): int {
+                def fibonacci(n: int): int {
                     if n == 1 || n == 2 {
                         return 1;
                     }
@@ -365,11 +365,11 @@ mod tests {
     fn recursive_counter() {
         assert_output_equal(
             indoc! {"
-                fn main() {
+                def main() {
                     count_to_zero(5);
                 }
 
-                fn count_to_zero(n: int) {
+                def count_to_zero(n: int) {
                     if n < 0 {
                         return;
                     }
@@ -385,11 +385,11 @@ mod tests {
     fn function_as_argument_to_function_call() {
         assert_output_equal(
             indoc! {"
-                fn main() {
+                def main() {
                     print(produce);
                 }
 
-                fn print(producer: () -> int) {
+                def print(producer: () -> int) {
                     var x: () -> int = producer;
                     debug x();
 
@@ -397,7 +397,7 @@ mod tests {
                     debug y();
                 }
 
-                fn produce(): int {
+                def produce(): int {
                     return 5;
                 }
             "},
@@ -409,15 +409,15 @@ mod tests {
     fn calling_function_returned_from_another_function_call() {
         assert_output_equal(
             indoc! {"
-                fn main() {
+                def main() {
                     debug foo()();
                 }
 
-                fn foo(): () -> int {
+                def foo(): () -> int {
                     return bar;
                 }
 
-                fn bar(): int {
+                def bar(): int {
                     return 25;
                 }
             "},
@@ -429,7 +429,7 @@ mod tests {
     fn debug_array() {
         assert_output_equal(
             indoc! {"
-                fn main() {
+                def main() {
                     debug [[]int [int 1, 2], [int 3, 4]][1][0];
 
                     var arr = [int 1, 3];
@@ -445,7 +445,7 @@ mod tests {
     fn assign_to_array() {
         assert_output_equal(
             indoc! {"
-                fn main() {
+                def main() {
                     var arr = [int 0, 1, 2];
 
                     arr[0] = 99;
@@ -469,7 +469,7 @@ mod tests {
     fn calling_array_elements() {
         assert_output_equal(
             indoc! {"
-                fn main() {
+                def main() {
                     var arr = [(int) -> int
                         add_one,
                         add_two,
@@ -483,15 +483,15 @@ mod tests {
                     }
                 }
 
-                fn add_one(n: int): int {
+                def add_one(n: int): int {
                     return n + 1;
                 }
 
-                fn add_two(n: int): int {
+                def add_two(n: int): int {
                     return n + 2;
                 }
 
-                fn add_three(n: int): int {
+                def add_three(n: int): int {
                     return n + 3;
                 }
             "},
@@ -503,7 +503,7 @@ mod tests {
     fn returning_array_from_a_function() {
         assert_output_equal(
             indoc! {"
-                fn main() {
+                def main() {
                     var arr_1 = foo();
                     var arr_2 = foo();
 
@@ -516,7 +516,7 @@ mod tests {
                     debug arr_2[0];
                 }
 
-                fn foo(): []int {
+                def foo(): []int {
                     return [int 0];
                 }
             "},
@@ -528,7 +528,7 @@ mod tests {
     fn iterate_array_using_each_loop_statement() {
         assert_output_equal(
             indoc! {"
-                fn main() {
+                def main() {
                     each n in [int 1, 2, 3, 4, 5, 6] {
                         if n == 3 {
                             continue;


### PR DESCRIPTION
- `fn` keyword is replaced with `def` keyword.
- Make parentheses optional in function definition when it does not receive any parameters.